### PR TITLE
Add tx validation

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,0 +1,33 @@
+/// Maximum contract size, in bytes.
+pub const CONTRACT_MAX_SIZE: u64 = 16 * 1024;
+
+/// Maximum number of inputs.
+pub const MAX_INPUTS: u8 = 8;
+
+/// Maximum number of outputs.
+pub const MAX_OUTPUTS: u8 = 8;
+
+/// Maximum number of witnesses.
+pub const MAX_WITNESSES: u8 = 16;
+
+/// Maximum gas per transaction.
+pub const MAX_GAS_PER_TX: u64 = 1000000;
+
+// TODO set max script length const
+/// Maximum length of script, in instructions.
+pub const MAX_SCRIPT_LENGTH: u64 = 1024 * 1024 * 1024;
+
+// TODO set max script length const
+/// Maximum length of script data, in bytes.
+pub const MAX_SCRIPT_DATA_LENGTH: u64 = 1024 * 1024 * 1024;
+
+/// Maximum number of static contracts.
+pub const MAX_STATIC_CONTRACTS: u64 = 255;
+
+// TODO set max predicate length value
+/// Maximum length of predicate, in instructions.
+pub const MAX_PREDICATE_LENGTH: u64 = 1024 * 1024;
+
+// TODO set max predicate data length value
+/// Maximum length of predicate data, in bytes.
+pub const MAX_PREDICATE_DATA_LENGTH: u64 = 1024 * 1024;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,11 @@
 #![feature(arbitrary_enum_discriminant)]
+#![feature(is_sorted)]
 
 // TODO Add docs
 
 mod transaction;
 
 pub mod bytes;
+pub mod consts;
 
-pub use transaction::{Color, Id, Input, Output, Root, Transaction, Witness};
+pub use transaction::{Color, Id, Input, Output, Root, Transaction, ValidationError, Witness};

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -7,8 +7,10 @@ use std::io::Write;
 use std::{io, mem};
 
 mod types;
+mod validation;
 
 pub use types::{Color, Id, Input, Output, Root, Witness};
+pub use validation::ValidationError;
 
 const WORD_SIZE: usize = mem::size_of::<Word>();
 const ID_SIZE: usize = mem::size_of::<Id>();

--- a/src/transaction/validation.rs
+++ b/src/transaction/validation.rs
@@ -1,0 +1,203 @@
+use super::{Color, Input, Output, Transaction, Witness};
+use crate::consts::*;
+
+use fuel_asm::Word;
+
+use std::mem;
+
+mod error;
+
+pub use error::ValidationError;
+
+const COLOR_SIZE: usize = mem::size_of::<Color>();
+
+impl Input {
+    pub fn validate(&self, index: usize, outputs: &[Output], witnesses: &[Witness]) -> Result<(), ValidationError> {
+        match self {
+            Self::Coin { predicate, .. } if predicate.len() > MAX_PREDICATE_LENGTH as usize => {
+                Err(ValidationError::InputCoinPredicateLength { index })
+            }
+
+            Self::Coin { predicate_data, .. } if predicate_data.len() > MAX_PREDICATE_DATA_LENGTH as usize => {
+                Err(ValidationError::InputCoinPredicateDataLength { index })
+            }
+
+            Self::Coin { witness_index, .. } if *witness_index as usize >= witnesses.len() => {
+                Err(ValidationError::InputCoinWitnessIndexBounds { index })
+            }
+
+            // ∀ inputContract ∃! outputContract : outputContract.inputIndex = inputContract.index
+            Self::Contract { .. }
+                if 1 != outputs
+                    .iter()
+                    .filter_map(|output| match output {
+                        Output::Contract { input_index, .. } if *input_index as usize == index => Some(()),
+                        _ => None,
+                    })
+                    .count() =>
+            {
+                Err(ValidationError::InputContractAssociatedOutputContract { index })
+            }
+
+            // TODO If h is the block height the UTXO being spent was created, transaction is
+            // invalid if `blockheight() < h + maturity`.
+            _ => Ok(()),
+        }
+    }
+}
+
+impl Output {
+    pub fn validate(&self, index: usize, inputs: &[Input]) -> Result<(), ValidationError> {
+        match self {
+            Self::Contract { input_index, .. } => match inputs.get(*input_index as usize) {
+                Some(Input::Contract { .. }) => Ok(()),
+                _ => Err(ValidationError::OutputContractInputIndex { index }),
+            },
+
+            _ => Ok(()),
+        }
+    }
+}
+
+impl Transaction {
+    pub fn validate(&self, block_height: Word) -> Result<(), ValidationError> {
+        if self.gas_price() > MAX_GAS_PER_TX {
+            Err(ValidationError::TransactionGasLimit)?
+        }
+
+        if block_height < self.maturity() as Word {
+            Err(ValidationError::TransactionMaturity)?;
+        }
+
+        if self.inputs().len() > MAX_INPUTS as usize {
+            Err(ValidationError::TransactionInputsMax)?
+        }
+
+        if self.outputs().len() > MAX_OUTPUTS as usize {
+            Err(ValidationError::TransactionOutputsMax)?
+        }
+
+        if self.witnesses().len() > MAX_WITNESSES as usize {
+            Err(ValidationError::TransactionWitnessesMax)?
+        }
+
+        let input_colors: Vec<&Color> = self.input_colors().collect();
+        for input_color in input_colors.as_slice() {
+            if self
+                .outputs()
+                .iter()
+                .filter_map(|output| match output {
+                    Output::Change { color, .. } if color != &Color::default() && input_color == &color => Some(()),
+                    _ => None,
+                })
+                .count()
+                > 1
+            {
+                Err(ValidationError::TransactionOutputChangeColorDuplicated)?
+            }
+        }
+
+        for (index, input) in self.inputs().iter().enumerate() {
+            input.validate(index, self.outputs(), self.witnesses())?;
+        }
+
+        for (index, output) in self.outputs().iter().enumerate() {
+            output.validate(index, self.inputs())?;
+            if let Output::Change { color, .. } = output {
+                if !input_colors.iter().any(|input_color| input_color == &color) {
+                    Err(ValidationError::TransactionOutputChangeColorNotFound)?
+                }
+            }
+        }
+
+        match self {
+            Self::Script {
+                outputs,
+                script,
+                script_data,
+                ..
+            } => {
+                if script.len() > MAX_SCRIPT_LENGTH as usize {
+                    Err(ValidationError::TransactionScriptLength)?;
+                }
+
+                if script_data.len() > MAX_SCRIPT_DATA_LENGTH as usize {
+                    Err(ValidationError::TransactionScriptDataLength)?;
+                }
+
+                outputs
+                    .iter()
+                    .enumerate()
+                    .try_for_each(|(index, output)| match output {
+                        Output::ContractCreated { .. } => {
+                            Err(ValidationError::TransactionScriptOutputContractCreated { index })
+                        }
+                        _ => Ok(()),
+                    })?;
+
+                Ok(())
+            }
+
+            Self::Create {
+                inputs,
+                outputs,
+                witnesses,
+                bytecode_witness_index,
+                static_contracts,
+                ..
+            } => {
+                match witnesses.get(*bytecode_witness_index as usize) {
+                    Some(witness) if witness.as_ref().len() as u64 * 4 > CONTRACT_MAX_SIZE => {
+                        Err(ValidationError::TransactionCreateBytecodeLen)?
+                    }
+                    None => Err(ValidationError::TransactionCreateBytecodeWitnessIndex)?,
+                    _ => (),
+                }
+
+                if static_contracts.len() > MAX_STATIC_CONTRACTS as usize {
+                    Err(ValidationError::TransactionCreateStaticContractsMax)?;
+                }
+
+                if !static_contracts.as_slice().is_sorted() {
+                    Err(ValidationError::TransactionCreateStaticContractsOrder)?;
+                }
+
+                // TODO Any contract with ID in staticContracts is not in the state
+                // TODO The computed contract ID (see below) is not equal to the contractID of
+                // the one OutputType.ContractCreated output
+
+                for (index, input) in inputs.iter().enumerate() {
+                    if let Input::Contract { .. } = input {
+                        Err(ValidationError::TransactionCreateInputContract { index })?
+                    }
+                }
+
+                let mut change_color_zero = false;
+                let mut contract_created = false;
+                for (index, output) in outputs.iter().enumerate() {
+                    match output {
+                        Output::Contract { .. } => Err(ValidationError::TransactionCreateOutputContract { index })?,
+                        Output::Variable { .. } => Err(ValidationError::TransactionCreateOutputVariable { index })?,
+
+                        Output::Change { color, .. } if color == &[0u8; COLOR_SIZE] && change_color_zero => {
+                            Err(ValidationError::TransactionCreateOutputChangeColorZero { index })?
+                        }
+                        Output::Change { color, .. } if color == &[0u8; COLOR_SIZE] => change_color_zero = true,
+                        Output::Change { .. } => {
+                            Err(ValidationError::TransactionCreateOutputChangeColorNonZero { index })?
+                        }
+
+                        Output::ContractCreated { .. } if contract_created => {
+                            Err(ValidationError::TransactionCreateOutputContractCreatedMultiple { index })?
+                        }
+                        Output::ContractCreated { .. } => contract_created = true,
+
+                        _ => (),
+                    }
+                }
+
+                Ok(())
+            }
+        }
+    }
+}

--- a/src/transaction/validation/error.rs
+++ b/src/transaction/validation/error.rs
@@ -1,0 +1,49 @@
+use std::{error, fmt, io};
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ValidationError {
+    InputCoinPredicateLength { index: usize },
+    InputCoinPredicateDataLength { index: usize },
+    InputCoinWitnessIndexBounds { index: usize },
+    InputContractAssociatedOutputContract { index: usize },
+    OutputContractInputIndex { index: usize },
+    TransactionCreateInputContract { index: usize },
+    TransactionCreateOutputContract { index: usize },
+    TransactionCreateOutputVariable { index: usize },
+    TransactionCreateOutputChangeColorZero { index: usize },
+    TransactionCreateOutputChangeColorNonZero { index: usize },
+    TransactionCreateOutputContractCreatedMultiple { index: usize },
+    TransactionCreateBytecodeLen,
+    TransactionCreateBytecodeWitnessIndex,
+    TransactionCreateStaticContractsMax,
+    TransactionCreateStaticContractsOrder,
+    TransactionScriptLength,
+    TransactionScriptDataLength,
+    TransactionScriptOutputContractCreated { index: usize },
+    TransactionGasLimit,
+    TransactionMaturity,
+    TransactionInputsMax,
+    TransactionOutputsMax,
+    TransactionWitnessesMax,
+    TransactionOutputChangeColorDuplicated,
+    TransactionOutputChangeColorNotFound,
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // TODO better describe the error variants
+        write!(f, "{:?}", self)
+    }
+}
+
+impl error::Error for ValidationError {
+    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
+        None
+    }
+}
+
+impl From<ValidationError> for io::Error {
+    fn from(v: ValidationError) -> io::Error {
+        io::Error::new(io::ErrorKind::Other, v)
+    }
+}

--- a/tests/transaction.rs
+++ b/tests/transaction.rs
@@ -3,6 +3,8 @@ use fuel_tx::*;
 use std::fmt;
 use std::io::{self, Read, Write};
 
+mod valid;
+
 pub fn assert_encoding_correct<T>(data: &[T])
 where
     T: Read + Write + fmt::Debug + Clone + PartialEq,

--- a/tests/valid/input.rs
+++ b/tests/valid/input.rs
@@ -1,0 +1,92 @@
+use super::d;
+use fuel_tx::consts::*;
+use fuel_tx::{Input, Output, ValidationError};
+
+#[test]
+fn coin() {
+    let witnesses = vec![vec![0xff; 128].into()];
+
+    Input::coin(
+        d(),
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        vec![0u8; MAX_PREDICATE_LENGTH as usize],
+        d(),
+    )
+    .validate(1, &[], witnesses.as_slice())
+    .unwrap();
+
+    Input::coin(
+        d(),
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![0u8; MAX_PREDICATE_DATA_LENGTH as usize],
+    )
+    .validate(1, &[], witnesses.as_slice())
+    .unwrap();
+
+    let err = Input::coin(
+        d(),
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        vec![0u8; MAX_PREDICATE_LENGTH as usize + 1],
+        d(),
+    )
+    .validate(1, &[], witnesses.as_slice())
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::InputCoinPredicateLength { index: 1 }, err);
+
+    let err = Input::coin(
+        d(),
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![0u8; MAX_PREDICATE_DATA_LENGTH as usize + 1],
+    )
+    .validate(1, &[], witnesses.as_slice())
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::InputCoinPredicateDataLength { index: 1 }, err);
+
+    let err = Input::coin(d(), d(), d(), d(), 1, d(), d(), d())
+        .validate(1, &[], witnesses.as_slice())
+        .err()
+        .unwrap();
+    assert_eq!(ValidationError::InputCoinWitnessIndexBounds { index: 1 }, err);
+}
+
+#[test]
+fn contract() {
+    Input::contract(d(), d(), d(), d())
+        .validate(1, &[Output::contract(1, d(), d())], &[])
+        .unwrap();
+
+    let err = Input::contract(d(), d(), d(), d()).validate(1, &[], &[]).err().unwrap();
+    assert_eq!(ValidationError::InputContractAssociatedOutputContract { index: 1 }, err);
+
+    let err = Input::contract(d(), d(), d(), d())
+        .validate(1, &[Output::coin(d(), d(), d())], &[])
+        .err()
+        .unwrap();
+    assert_eq!(ValidationError::InputContractAssociatedOutputContract { index: 1 }, err);
+
+    let err = Input::contract(d(), d(), d(), d())
+        .validate(1, &[Output::contract(2, d(), d())], &[])
+        .err()
+        .unwrap();
+    assert_eq!(ValidationError::InputContractAssociatedOutputContract { index: 1 }, err);
+}

--- a/tests/valid/mod.rs
+++ b/tests/valid/mod.rs
@@ -1,0 +1,7 @@
+mod input;
+mod output;
+mod transaction;
+
+pub fn d<T: Default>() -> T {
+    Default::default()
+}

--- a/tests/valid/output.rs
+++ b/tests/valid/output.rs
@@ -1,0 +1,64 @@
+use super::d;
+use fuel_tx::{Input, Output, ValidationError};
+
+#[test]
+fn coin() {
+    Output::coin(d(), d(), d()).validate(1, &[]).unwrap();
+}
+
+#[test]
+fn contract() {
+    Output::contract(1, d(), d())
+        .validate(
+            2,
+            &[
+                Input::coin(d(), d(), d(), d(), d(), d(), d(), d()),
+                Input::contract(d(), d(), d(), d()),
+            ],
+        )
+        .unwrap();
+
+    let err = Output::contract(0, d(), d())
+        .validate(
+            2,
+            &[
+                Input::coin(d(), d(), d(), d(), d(), d(), d(), d()),
+                Input::contract(d(), d(), d(), d()),
+            ],
+        )
+        .err()
+        .unwrap();
+    assert_eq!(ValidationError::OutputContractInputIndex { index: 2 }, err);
+
+    let err = Output::contract(2, d(), d())
+        .validate(
+            2,
+            &[
+                Input::coin(d(), d(), d(), d(), d(), d(), d(), d()),
+                Input::contract(d(), d(), d(), d()),
+            ],
+        )
+        .err()
+        .unwrap();
+    assert_eq!(ValidationError::OutputContractInputIndex { index: 2 }, err);
+}
+
+#[test]
+fn withdrawal() {
+    Output::withdrawal(d(), d(), d()).validate(1, &[]).unwrap();
+}
+
+#[test]
+fn change() {
+    Output::change(d(), d(), d()).validate(1, &[]).unwrap();
+}
+
+#[test]
+fn variable() {
+    Output::variable(d(), d(), d()).validate(1, &[]).unwrap();
+}
+
+#[test]
+fn contract_created() {
+    Output::contract_created(d()).validate(1, &[]).unwrap();
+}

--- a/tests/valid/transaction.rs
+++ b/tests/valid/transaction.rs
@@ -1,0 +1,498 @@
+use super::d;
+use fuel_tx::consts::*;
+use fuel_tx::{Color, Id, Input, Output, Transaction, ValidationError};
+
+#[test]
+fn gas_price() {
+    Transaction::script(MAX_GAS_PER_TX, d(), d(), d(), d(), d(), d(), d())
+        .validate(1000)
+        .unwrap();
+
+    Transaction::create(
+        MAX_GAS_PER_TX,
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .unwrap();
+
+    let err = Transaction::script(MAX_GAS_PER_TX + 1, d(), d(), d(), d(), d(), d(), d())
+        .validate(1000)
+        .err()
+        .unwrap();
+    assert_eq!(ValidationError::TransactionGasLimit, err);
+
+    let err = Transaction::create(
+        MAX_GAS_PER_TX + 1,
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionGasLimit, err);
+}
+
+#[test]
+fn maturity() {
+    Transaction::script(d(), d(), 1000, d(), d(), d(), d(), d())
+        .validate(1000)
+        .unwrap();
+
+    Transaction::create(d(), d(), 1000, 0, d(), d(), d(), d(), vec![vec![0xfau8].into()])
+        .validate(1000)
+        .unwrap();
+
+    let err = Transaction::script(d(), d(), 1001, d(), d(), d(), d(), d())
+        .validate(1000)
+        .err()
+        .unwrap();
+    assert_eq!(ValidationError::TransactionMaturity, err);
+
+    let err = Transaction::create(d(), d(), 1001, 0, d(), d(), d(), d(), vec![vec![0xfau8].into()])
+        .validate(1000)
+        .err()
+        .unwrap();
+    assert_eq!(ValidationError::TransactionMaturity, err);
+}
+
+#[test]
+fn max_iow() {
+    Transaction::script(
+        d(),
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![Input::coin(d(), d(), d(), d(), d(), d(), d(), d()); MAX_INPUTS as usize],
+        vec![Output::coin(d(), d(), d()); MAX_OUTPUTS as usize],
+        vec![vec![0xfau8].into(); MAX_WITNESSES as usize],
+    )
+    .validate(1000)
+    .unwrap();
+
+    Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![Input::coin(d(), d(), d(), d(), d(), d(), d(), d()); MAX_INPUTS as usize],
+        vec![Output::coin(d(), d(), d()); MAX_OUTPUTS as usize],
+        vec![vec![0xfau8].into(); MAX_WITNESSES as usize],
+    )
+    .validate(1000)
+    .unwrap();
+
+    let err = Transaction::script(
+        d(),
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![Input::contract(d(), d(), d(), d()); MAX_INPUTS as usize + 1],
+        vec![Output::variable(d(), d(), d()); MAX_OUTPUTS as usize],
+        vec![vec![0xfau8].into(); MAX_WITNESSES as usize],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionInputsMax, err);
+
+    let err = Transaction::script(
+        d(),
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![Input::contract(d(), d(), d(), d()); MAX_INPUTS as usize],
+        vec![Output::variable(d(), d(), d()); MAX_OUTPUTS as usize + 1],
+        vec![vec![0xfau8].into(); MAX_WITNESSES as usize],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionOutputsMax, err);
+
+    let err = Transaction::script(
+        d(),
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![Input::contract(d(), d(), d(), d()); MAX_INPUTS as usize],
+        vec![Output::variable(d(), d(), d()); MAX_OUTPUTS as usize],
+        vec![vec![0xfau8].into(); MAX_WITNESSES as usize + 1],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionWitnessesMax, err);
+}
+
+#[test]
+fn output_change_color() {
+    let mut a = Color::default();
+    let mut b = Color::default();
+    let mut c = Color::default();
+
+    a[0] = 0xfa;
+    b[0] = 0xfb;
+    c[0] = 0xfc;
+
+    Transaction::script(
+        d(),
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![
+            Input::coin(d(), d(), d(), a, 0, d(), d(), d()),
+            Input::coin(d(), d(), d(), b, 0, d(), d(), d()),
+        ],
+        vec![Output::change(d(), d(), a), Output::change(d(), d(), b)],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .unwrap();
+
+    let err = Transaction::script(
+        d(),
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![
+            Input::coin(d(), d(), d(), a, 0, d(), d(), d()),
+            Input::coin(d(), d(), d(), b, 0, d(), d(), d()),
+        ],
+        vec![Output::change(d(), d(), a), Output::change(d(), d(), a)],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionOutputChangeColorDuplicated, err);
+
+    let err = Transaction::script(
+        d(),
+        d(),
+        d(),
+        d(),
+        d(),
+        vec![
+            Input::coin(d(), d(), d(), a, 0, d(), d(), d()),
+            Input::coin(d(), d(), d(), b, 0, d(), d(), d()),
+        ],
+        vec![Output::change(d(), d(), a), Output::change(d(), d(), c)],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionOutputChangeColorNotFound, err);
+}
+
+#[test]
+fn script() {
+    Transaction::script(
+        d(),
+        d(),
+        d(),
+        vec![0xfa; MAX_SCRIPT_LENGTH as usize],
+        vec![0xfb; MAX_SCRIPT_DATA_LENGTH as usize],
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .unwrap();
+
+    let err = Transaction::script(
+        d(),
+        d(),
+        d(),
+        vec![0xfa; MAX_SCRIPT_LENGTH as usize],
+        vec![0xfb; MAX_SCRIPT_DATA_LENGTH as usize],
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::contract_created(d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(
+        ValidationError::TransactionScriptOutputContractCreated { index: 0 },
+        err
+    );
+
+    let err = Transaction::script(
+        d(),
+        d(),
+        d(),
+        vec![0xfa; MAX_SCRIPT_LENGTH as usize + 1],
+        vec![0xfb; MAX_SCRIPT_DATA_LENGTH as usize],
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionScriptLength, err);
+
+    let err = Transaction::script(
+        d(),
+        d(),
+        d(),
+        vec![0xfa; MAX_SCRIPT_LENGTH as usize],
+        vec![0xfb; MAX_SCRIPT_DATA_LENGTH as usize + 1],
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionScriptDataLength, err);
+}
+
+#[test]
+fn create() {
+    let mut a = Color::default();
+    let mut b = Color::default();
+    let mut c = Color::default();
+
+    a[0] = 0xfa;
+    b[0] = 0xfb;
+    c[0] = 0xfc;
+
+    Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .unwrap();
+
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![Input::contract(d(), d(), d(), d())],
+        vec![Output::contract(0, d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionCreateInputContract { index: 0 }, err);
+
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::variable(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionCreateOutputVariable { index: 0 }, err);
+
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![
+            Input::coin(d(), d(), d(), d(), 0, d(), d(), d()),
+            Input::coin(d(), d(), d(), a, 0, d(), d(), d()),
+        ],
+        vec![Output::change(d(), d(), d()), Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(
+        ValidationError::TransactionCreateOutputChangeColorZero { index: 1 },
+        err
+    );
+
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![
+            Input::coin(d(), d(), d(), d(), 0, d(), d(), d()),
+            Input::coin(d(), d(), d(), a, 0, d(), d(), d()),
+        ],
+        vec![Output::change(d(), d(), d()), Output::change(d(), d(), a)],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(
+        ValidationError::TransactionCreateOutputChangeColorNonZero { index: 1 },
+        err
+    );
+
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![
+            Input::coin(d(), d(), d(), d(), 0, d(), d(), d()),
+            Input::coin(d(), d(), d(), a, 0, d(), d(), d()),
+        ],
+        vec![Output::contract_created(d()); 2],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(
+        ValidationError::TransactionCreateOutputContractCreatedMultiple { index: 1 },
+        err
+    );
+
+    Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8; CONTRACT_MAX_SIZE as usize / 4].into()],
+    )
+    .validate(1000)
+    .unwrap();
+
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        d(),
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8; 1 + CONTRACT_MAX_SIZE as usize / 4].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionCreateBytecodeLen, err);
+
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        1,
+        d(),
+        d(),
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionCreateBytecodeWitnessIndex, err);
+
+    let mut id = Id::default();
+    let mut static_contracts = (0..MAX_STATIC_CONTRACTS as u64)
+        .map(|i| {
+            id[..8].copy_from_slice(&i.to_be_bytes());
+            id
+        })
+        .collect::<Vec<Id>>();
+
+    Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        static_contracts.clone(),
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .unwrap();
+
+    id.iter_mut().for_each(|i| *i = 0xff);
+    static_contracts.push(id);
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        static_contracts.clone(),
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionCreateStaticContractsMax, err);
+
+    static_contracts.pop();
+    static_contracts[0][0] = 0xff;
+    let err = Transaction::create(
+        d(),
+        d(),
+        d(),
+        0,
+        d(),
+        static_contracts,
+        vec![Input::coin(d(), d(), d(), d(), 0, d(), d(), d())],
+        vec![Output::change(d(), d(), d())],
+        vec![vec![0xfau8].into()],
+    )
+    .validate(1000)
+    .err()
+    .unwrap();
+    assert_eq!(ValidationError::TransactionCreateStaticContractsOrder, err);
+}


### PR DESCRIPTION
Transaction validity is critical to the chain consistency.

The specification of the routines is defined in
https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_validity.md

Some of these specs may intersect with VM logic; these intersections are
outside the scope of this lib and should be implemented directly in the
VM.

Resolves #3