### PR TITLE
Add fn to fetch offset of input coin data

### DIFF
--- a/src/bytes.rs
+++ b/src/bytes.rs
@@ -32,6 +32,16 @@ pub fn store_bytes<'a>(mut buf: &'a mut [u8], bytes: &[u8]) -> io::Result<(usize
     Ok((WORD_SIZE + bytes.len() + pad, buf))
 }
 
+pub const fn padded_len(bytes: &[u8]) -> usize {
+    let pad = bytes.len() % WORD_SIZE;
+
+    if pad == 0 {
+        bytes.len()
+    } else {
+        bytes.len() + WORD_SIZE - pad
+    }
+}
+
 pub fn store_raw_bytes<'a>(mut buf: &'a mut [u8], bytes: &[u8]) -> io::Result<(usize, &'a mut [u8])> {
     let pad = bytes.len() % WORD_SIZE;
     let pad = if pad == 0 { 0 } else { WORD_SIZE - pad };

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,3 @@
-#![feature(arbitrary_enum_discriminant)]
-#![feature(is_sorted)]
-
 // TODO Add docs
 
 mod transaction;
@@ -8,4 +5,6 @@ mod transaction;
 pub mod bytes;
 pub mod consts;
 
-pub use transaction::{Color, Id, Input, Output, Root, Transaction, ValidationError, Witness};
+pub use transaction::{
+    Address, Color, ContractAddress, Hash, Input, Output, Salt, Transaction, ValidationError, Witness,
+};

--- a/src/transaction/types.rs
+++ b/src/transaction/types.rs
@@ -2,9 +2,11 @@ mod input;
 mod output;
 mod witness;
 
+pub type Address = [u8; 32];
 pub type Color = [u8; 32];
-pub type Id = [u8; 32];
-pub type Root = [u8; 32];
+pub type ContractAddress = [u8; 32];
+pub type Hash = [u8; 32];
+pub type Salt = [u8; 32];
 
 pub use input::Input;
 pub use output::Output;

--- a/src/transaction/validation.rs
+++ b/src/transaction/validation.rs
@@ -158,13 +158,13 @@ impl Transaction {
                     Err(ValidationError::TransactionCreateStaticContractsMax)?;
                 }
 
-                if !static_contracts.as_slice().is_sorted() {
+                if !static_contracts.as_slice().windows(2).all(|w| w[0] <= w[1]) {
                     Err(ValidationError::TransactionCreateStaticContractsOrder)?;
                 }
 
-                // TODO Any contract with ID in staticContracts is not in the state
-                // TODO The computed contract ID (see below) is not equal to the contractID of
-                // the one OutputType.ContractCreated output
+                // TODO Any contract with ADDRESS in staticContracts is not in the state
+                // TODO The computed contract ADDRESS (see below) is not equal to the
+                // contractADDRESS of the one OutputType.ContractCreated output
 
                 for (index, input) in inputs.iter().enumerate() {
                     if let Input::Contract { .. } = input {

--- a/tests/valid/mod.rs
+++ b/tests/valid/mod.rs
@@ -2,6 +2,4 @@ mod input;
 mod output;
 mod transaction;
 
-pub fn d<T: Default>() -> T {
-    Default::default()
-}
+pub use super::d;

--- a/tests/valid/transaction.rs
+++ b/tests/valid/transaction.rs
@@ -1,6 +1,6 @@
 use super::d;
 use fuel_tx::consts::*;
-use fuel_tx::{Color, Id, Input, Output, Transaction, ValidationError};
+use fuel_tx::{Color, ContractAddress, Input, Output, Transaction, ValidationError};
 
 #[test]
 fn gas_price() {
@@ -438,13 +438,13 @@ fn create() {
     .unwrap();
     assert_eq!(ValidationError::TransactionCreateBytecodeWitnessIndex, err);
 
-    let mut id = Id::default();
+    let mut id = ContractAddress::default();
     let mut static_contracts = (0..MAX_STATIC_CONTRACTS as u64)
         .map(|i| {
             id[..8].copy_from_slice(&i.to_be_bytes());
             id
         })
-        .collect::<Vec<Id>>();
+        .collect::<Vec<ContractAddress>>();
 
     Transaction::create(
         d(),


### PR DESCRIPTION
The interpreter will need to access the serialized transaction input
data for coin type when executing the predicate verification.

For this, we need an encapsulated method that will, provided an input
index, return its relative offset in the serialized bytes.