### PR TITLE
Use stable Rust in CI

### DIFF
--- a/.github/workflows/cargo_test.yml
+++ b/.github/workflows/cargo_test.yml
@@ -29,7 +29,7 @@ jobs:
       uses: actions-rs/toolchain@v1
       with:
         profile: minimal
-        toolchain: nightly
+        toolchain: stable
         override: true
 
     - name: Install rustfmt


### PR DESCRIPTION
As of #7, can use Rust `stable` instead of `nightly`.