### PR TITLE
Add `script_offset` method for `Transaction`

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -284,6 +284,12 @@ impl Transaction {
         matches!(self, Self::Script { .. })
     }
 
+    /// For a serialized transaction of type `Script`, return the bytes offset
+    /// of the script
+    pub const fn script_offset(&self) -> usize {
+        TRANSACTION_SCRIPT_FIXED_SIZE
+    }
+
     /// For a transaction of type `Create`, return the offset of the data
     /// relative to the serialized transaction for a given index of inputs,
     /// if this input is of type `Coin`.

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -383,8 +383,10 @@ fn script_input_coin_data_offset() {
                         buffer.iter_mut().for_each(|b| *b = 0x00);
                         tx.read(buffer.as_mut_slice()).expect("Failed to serialize input");
 
-                        let offset = tx.input_coin_predicate_offset(offset).expect("Failed to fetch offset");
+                        let script_offset = tx.script_offset();
+                        assert_eq!(script.as_slice(), &buffer[script_offset..script_offset + script.len()]);
 
+                        let offset = tx.input_coin_predicate_offset(offset).expect("Failed to fetch offset");
                         assert_eq!(predicate.as_slice(), &buffer[offset..offset + predicate.len()]);
                     }
                 }


### PR DESCRIPTION
THe script offset must be known by the VM to perform its execution.

It depends on the serialization of the transaction, so it must be
defined in this crate.