### PR TITLE
Add script data offset function to tx

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -292,10 +292,10 @@ impl Transaction {
 
     /// For a serialized transaction of type `Script`, return the bytes offset
     /// of the script data
-    pub fn script_data_offset(&self) -> usize {
+    pub fn script_data_offset(&self) -> Option<usize> {
         match &self {
-            Self::Script { script, .. } => TRANSACTION_SCRIPT_FIXED_SIZE + bytes::padded_len(script.as_slice()),
-            _ => 0,
+            Self::Script { script, .. } => Some(TRANSACTION_SCRIPT_FIXED_SIZE + bytes::padded_len(script.as_slice())),
+            _ => None,
         }
     }
 

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -386,7 +386,9 @@ fn script_input_coin_data_offset() {
                         let script_offset = Transaction::script_offset();
                         assert_eq!(script.as_slice(), &buffer[script_offset..script_offset + script.len()]);
 
-                        let script_data_offset = tx.script_data_offset();
+                        let script_data_offset = tx
+                            .script_data_offset()
+                            .expect("Transaction is Script and should return data offset");
                         assert_eq!(
                             script_data.as_slice(),
                             &buffer[script_data_offset..script_data_offset + script_data.len()]


### PR DESCRIPTION
Script data offset will need to be accessible to users of the
transaction API in order to create data for scripts