### PR TITLE
Update Transaction::default to valid executable tx

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -94,7 +94,7 @@ impl Default for Transaction {
         // The Return op is mandatory for the execution of any context
         let script = Opcode::RET(0x10).to_bytes().to_vec();
 
-        Transaction::script(1, 1000000, 1, script, vec![], vec![], vec![], vec![])
+        Transaction::script(0, 1000000, 0, script, vec![], vec![], vec![], vec![])
     }
 }
 


### PR DESCRIPTION
The transaction default function should comply with the specs and be
executable under the VM context.

A create type will always depend on some contract deployment so an empty
script is the minimum code approach.