### PR TITLE
Change Output::coin to use ContractAddress

### DIFF
--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -134,7 +134,11 @@ fn output() {
     let rng = &mut rng_base;
 
     assert_encoding_correct(&[
-        Output::coin(Address::random(rng), rng.next_u64(), Color::random(rng)),
+        Output::coin(
+            ContractAddress::random(rng),
+            rng.next_u64(),
+            Color::random(rng),
+        ),
         Output::contract(
             rng.next_u32().to_be_bytes()[0],
             Hash::random(rng),
@@ -158,7 +162,11 @@ fn transaction() {
         Hash::random(rng),
         ContractAddress::random(rng),
     );
-    let o = Output::coin(Address::random(rng), rng.next_u64(), Color::random(rng));
+    let o = Output::coin(
+        ContractAddress::random(rng),
+        rng.next_u64(),
+        Color::random(rng),
+    );
     let w = Witness::random(rng);
 
     assert_encoding_correct(&[
@@ -327,7 +335,7 @@ fn create_input_coin_data_offset() {
     let outputs: Vec<Vec<Output>> = vec![
         vec![],
         vec![Output::coin(
-            Address::random(rng),
+            ContractAddress::random(rng),
             rng.next_u64(),
             Color::random(rng),
         )],
@@ -437,7 +445,7 @@ fn script_input_coin_data_offset() {
     let outputs: Vec<Vec<Output>> = vec![
         vec![],
         vec![Output::coin(
-            Address::random(rng),
+            ContractAddress::random(rng),
             rng.next_u64(),
             Color::random(rng),
         )],

--- a/tests/txid.rs
+++ b/tests/txid.rs
@@ -155,7 +155,11 @@ fn id() {
     let outputs = vec![
         vec![],
         vec![
-            Output::coin(Address::random(rng), rng.next_u64(), Color::random(rng)),
+            Output::coin(
+                ContractAddress::random(rng),
+                rng.next_u64(),
+                Color::random(rng),
+            ),
             Output::contract(
                 rng.next_u32().to_be_bytes()[0],
                 Hash::random(rng),

--- a/tests/valid_cases/input.rs
+++ b/tests/valid_cases/input.rs
@@ -129,7 +129,7 @@ fn contract() {
     .validate(
         1,
         &[Output::coin(
-            Address::random(rng),
+            ContractAddress::random(rng),
             rng.next_u64(),
             Color::random(rng),
         )],

--- a/tests/valid_cases/output.rs
+++ b/tests/valid_cases/output.rs
@@ -7,9 +7,13 @@ fn coin() {
     let mut rng_base = StdRng::seed_from_u64(8586);
     let rng = &mut rng_base;
 
-    Output::coin(Address::random(rng), rng.next_u64(), Color::random(rng))
-        .validate(1, &[])
-        .unwrap();
+    Output::coin(
+        ContractAddress::random(rng),
+        rng.next_u64(),
+        Color::random(rng),
+    )
+    .validate(1, &[])
+    .unwrap();
 }
 
 #[test]

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -164,7 +164,11 @@ fn max_iow() {
             MAX_INPUTS as usize
         ],
         vec![
-            Output::coin(Address::random(rng), rng.next_u64(), Color::random(rng));
+            Output::coin(
+                ContractAddress::random(rng),
+                rng.next_u64(),
+                Color::random(rng)
+            );
             MAX_OUTPUTS as usize
         ],
         vec![Witness::random(rng); MAX_WITNESSES as usize],
@@ -193,7 +197,11 @@ fn max_iow() {
             MAX_INPUTS as usize
         ],
         vec![
-            Output::coin(Address::random(rng), rng.next_u64(), Color::random(rng));
+            Output::coin(
+                ContractAddress::random(rng),
+                rng.next_u64(),
+                Color::random(rng)
+            );
             MAX_OUTPUTS as usize
         ],
         vec![Witness::random(rng); MAX_WITNESSES as usize],


### PR DESCRIPTION
The interpreter mapping expect a ContractAddress + Coin to map coin
balances.

The types `Address` and `ContractAddress` are split - even with similar
memory representation. This leads to the need of updating the
`Output::Coin` type to use `ContractAddress`