### PR TITLE
Rename ContractAddress to ContractId

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,5 @@ pub mod consts;
 pub mod crypto;
 
 pub use transaction::{
-    Address, Color, ContractAddress, Hash, Input, Output, Salt, Transaction, ValidationError,
-    Witness,
+    Address, Color, ContractId, Hash, Input, Output, Salt, Transaction, ValidationError, Witness,
 };

--- a/src/transaction/types.rs
+++ b/src/transaction/types.rs
@@ -94,6 +94,6 @@ pub use witness::Witness;
 
 key!(Address, 32);
 key!(Color, 32);
-key!(ContractAddress, 32);
+key!(ContractId, 32);
 key!(Hash, 32);
 key!(Salt, 32);

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -1,4 +1,4 @@
-use super::{Address, Color, ContractAddress, Hash};
+use super::{Address, Color, ContractId, Hash};
 use crate::bytes::{self, SizedBytes};
 
 use fuel_asm::Word;
@@ -22,7 +22,7 @@ const INPUT_CONTRACT_SIZE: usize = WORD_SIZE // Identifier
     + Hash::size_of() // UTXO Id
     + Hash::size_of() // Balance root
     + Hash::size_of() // State root
-    + ContractAddress::size_of(); // Contract address
+    + ContractId::size_of(); // Contract address
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum InputRepr {
@@ -62,7 +62,7 @@ pub enum Input {
         utxo_id: Hash,
         balance_root: Hash,
         state_root: Hash,
-        contract_id: ContractAddress,
+        contract_id: ContractId,
     },
 }
 
@@ -122,7 +122,7 @@ impl Input {
         utxo_id: Hash,
         balance_root: Hash,
         state_root: Hash,
-        contract_id: ContractAddress,
+        contract_id: ContractId,
     ) -> Self {
         Self::Contract {
             utxo_id,

--- a/src/transaction/types/output.rs
+++ b/src/transaction/types/output.rs
@@ -1,4 +1,4 @@
-use super::{Address, Color, ContractAddress, Hash};
+use super::{Address, Color, ContractId, Hash};
 use crate::bytes::{self, SizedBytes};
 
 use fuel_asm::Word;
@@ -19,7 +19,7 @@ const OUTPUT_CONTRACT_SIZE: usize = WORD_SIZE // Identifier
     + Hash::size_of(); // State root
 
 const OUTPUT_CONTRACT_CREATED_SIZE: usize = WORD_SIZE // Identifier
-    + ContractAddress::size_of(); // Contract Id
+    + ContractId::size_of(); // Contract Id
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 enum OutputRepr {
@@ -96,7 +96,7 @@ pub enum Output {
     },
 
     ContractCreated {
-        contract_id: ContractAddress,
+        contract_id: ContractId,
     },
 }
 
@@ -148,7 +148,7 @@ impl Output {
         Self::Variable { to, amount, color }
     }
 
-    pub const fn contract_created(contract_id: ContractAddress) -> Self {
+    pub const fn contract_created(contract_id: ContractId) -> Self {
         Self::ContractCreated { contract_id }
     }
 

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -123,7 +123,7 @@ fn input() {
             Hash::random(rng),
             Hash::random(rng),
             Hash::random(rng),
-            ContractAddress::random(rng),
+            ContractId::random(rng),
         ),
     ]);
 }
@@ -143,7 +143,7 @@ fn output() {
         Output::withdrawal(Address::random(rng), rng.next_u64(), Color::random(rng)),
         Output::change(Address::random(rng), rng.next_u64(), Color::random(rng)),
         Output::variable(Address::random(rng), rng.next_u64(), Color::random(rng)),
-        Output::contract_created(ContractAddress::random(rng)),
+        Output::contract_created(ContractId::random(rng)),
     ]);
 }
 
@@ -156,7 +156,7 @@ fn transaction() {
         Hash::random(rng),
         Hash::random(rng),
         Hash::random(rng),
-        ContractAddress::random(rng),
+        ContractId::random(rng),
     );
     let o = Output::coin(Address::random(rng), rng.next_u64(), Color::random(rng));
     let w = Witness::random(rng);
@@ -238,7 +238,7 @@ fn transaction() {
             rng.next_u64(),
             rng.next_u32().to_be_bytes()[0],
             Salt::random(rng),
-            vec![ContractAddress::random(rng)],
+            vec![ContractId::random(rng)],
             vec![i.clone()],
             vec![o.clone()],
             vec![w.clone()],
@@ -301,10 +301,10 @@ fn create_input_coin_data_offset() {
     let bytecode_witness_index = 0x00;
     let salt = Salt::random(rng);
 
-    let static_contracts: Vec<Vec<ContractAddress>> = vec![
+    let static_contracts: Vec<Vec<ContractId>> = vec![
         vec![],
-        vec![ContractAddress::random(rng)],
-        vec![ContractAddress::random(rng), ContractAddress::random(rng)],
+        vec![ContractId::random(rng)],
+        vec![ContractId::random(rng), ContractId::random(rng)],
     ];
     let inputs: Vec<Vec<Input>> = vec![
         vec![],
@@ -312,14 +312,14 @@ fn create_input_coin_data_offset() {
             Hash::random(rng),
             Hash::random(rng),
             Hash::random(rng),
-            ContractAddress::random(rng),
+            ContractId::random(rng),
         )],
         vec![
             Input::contract(
                 Hash::random(rng),
                 Hash::random(rng),
                 Hash::random(rng),
-                ContractAddress::random(rng)
+                ContractId::random(rng)
             );
             2
         ],
@@ -417,20 +417,20 @@ fn script_input_coin_data_offset() {
             Hash::random(rng),
             Hash::random(rng),
             Hash::random(rng),
-            ContractAddress::random(rng),
+            ContractId::random(rng),
         )],
         vec![
             Input::contract(
                 Hash::random(rng),
                 Hash::random(rng),
                 Hash::random(rng),
-                ContractAddress::random(rng),
+                ContractId::random(rng),
             ),
             Input::contract(
                 Hash::random(rng),
                 Hash::random(rng),
                 Hash::random(rng),
-                ContractAddress::random(rng),
+                ContractId::random(rng),
             ),
         ],
     ];

--- a/tests/txid.rs
+++ b/tests/txid.rs
@@ -147,7 +147,7 @@ fn id() {
                 Hash::random(rng),
                 Hash::random(rng),
                 Hash::random(rng),
-                ContractAddress::random(rng),
+                ContractId::random(rng),
             ),
         ],
     ];
@@ -164,7 +164,7 @@ fn id() {
             Output::withdrawal(Address::random(rng), rng.next_u64(), Color::random(rng)),
             Output::change(Address::random(rng), rng.next_u64(), Color::random(rng)),
             Output::variable(Address::random(rng), rng.next_u64(), Color::random(rng)),
-            Output::contract_created(ContractAddress::random(rng)),
+            Output::contract_created(ContractId::random(rng)),
         ],
     ];
 
@@ -182,7 +182,7 @@ fn id() {
     ];
     let static_contracts = vec![
         vec![],
-        vec![ContractAddress::random(rng), ContractAddress::random(rng)],
+        vec![ContractId::random(rng), ContractId::random(rng)],
     ];
 
     for inputs in inputs.iter() {

--- a/tests/valid_cases/input.rs
+++ b/tests/valid_cases/input.rs
@@ -97,7 +97,7 @@ fn contract() {
         Hash::random(rng),
         Hash::random(rng),
         Hash::random(rng),
-        ContractAddress::random(rng),
+        ContractId::random(rng),
     )
     .validate(
         1,
@@ -110,7 +110,7 @@ fn contract() {
         Hash::random(rng),
         Hash::random(rng),
         Hash::random(rng),
-        ContractAddress::random(rng),
+        ContractId::random(rng),
     )
     .validate(1, &[], &[])
     .err()
@@ -124,7 +124,7 @@ fn contract() {
         Hash::random(rng),
         Hash::random(rng),
         Hash::random(rng),
-        ContractAddress::random(rng),
+        ContractId::random(rng),
     )
     .validate(
         1,
@@ -146,7 +146,7 @@ fn contract() {
         Hash::random(rng),
         Hash::random(rng),
         Hash::random(rng),
-        ContractAddress::random(rng),
+        ContractId::random(rng),
     )
     .validate(
         1,

--- a/tests/valid_cases/output.rs
+++ b/tests/valid_cases/output.rs
@@ -35,7 +35,7 @@ fn contract() {
                     Hash::random(rng),
                     Hash::random(rng),
                     Hash::random(rng),
-                    ContractAddress::random(rng),
+                    ContractId::random(rng),
                 ),
             ],
         )
@@ -59,7 +59,7 @@ fn contract() {
                     Hash::random(rng),
                     Hash::random(rng),
                     Hash::random(rng),
-                    ContractAddress::random(rng),
+                    ContractId::random(rng),
                 ),
             ],
         )
@@ -85,7 +85,7 @@ fn contract() {
                     Hash::random(rng),
                     Hash::random(rng),
                     Hash::random(rng),
-                    ContractAddress::random(rng),
+                    ContractId::random(rng),
                 ),
             ],
         )
@@ -129,7 +129,7 @@ fn contract_created() {
     let mut rng_base = StdRng::seed_from_u64(8586);
     let rng = &mut rng_base;
 
-    Output::contract_created(ContractAddress::random(rng))
+    Output::contract_created(ContractId::random(rng))
         .validate(1, &[])
         .unwrap();
 }

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -212,7 +212,7 @@ fn max_iow() {
                 Hash::random(rng),
                 Hash::random(rng),
                 Hash::random(rng),
-                ContractAddress::random(rng)
+                ContractId::random(rng)
             );
             MAX_INPUTS as usize + 1
         ],
@@ -238,7 +238,7 @@ fn max_iow() {
                 Hash::random(rng),
                 Hash::random(rng),
                 Hash::random(rng),
-                ContractAddress::random(rng)
+                ContractId::random(rng)
             );
             MAX_INPUTS as usize
         ],
@@ -264,7 +264,7 @@ fn max_iow() {
                 Hash::random(rng),
                 Hash::random(rng),
                 Hash::random(rng),
-                ContractAddress::random(rng)
+                ContractId::random(rng)
             );
             MAX_INPUTS as usize
         ],
@@ -455,7 +455,7 @@ fn script() {
             Witness::random(rng).into_inner(),
             Witness::random(rng).into_inner(),
         )],
-        vec![Output::contract_created(ContractAddress::random(rng))],
+        vec![Output::contract_created(ContractId::random(rng))],
         vec![Witness::random(rng)],
     )
     .validate(block_height)
@@ -482,7 +482,7 @@ fn script() {
             Witness::random(rng).into_inner(),
             Witness::random(rng).into_inner(),
         )],
-        vec![Output::contract_created(ContractAddress::random(rng))],
+        vec![Output::contract_created(ContractId::random(rng))],
         vec![Witness::random(rng)],
     )
     .validate(block_height)
@@ -562,7 +562,7 @@ fn create() {
             Hash::random(rng),
             Hash::random(rng),
             Hash::random(rng),
-            ContractAddress::random(rng),
+            ContractId::random(rng),
         )],
         vec![Output::contract(0, Hash::random(rng), Hash::random(rng))],
         vec![Witness::random(rng)],
@@ -725,8 +725,8 @@ fn create() {
             ),
         ],
         vec![
-            Output::contract_created(ContractAddress::random(rng)),
-            Output::contract_created(ContractAddress::random(rng)),
+            Output::contract_created(ContractId::random(rng)),
+            Output::contract_created(ContractId::random(rng)),
         ],
         vec![Witness::random(rng)],
     )
@@ -823,13 +823,13 @@ fn create() {
     .unwrap();
     assert_eq!(ValidationError::TransactionCreateBytecodeWitnessIndex, err);
 
-    let mut id = ContractAddress::default();
+    let mut id = ContractId::default();
     let mut static_contracts = (0..MAX_STATIC_CONTRACTS as u64)
         .map(|i| {
             id[..8].copy_from_slice(&i.to_be_bytes());
             id
         })
-        .collect::<Vec<ContractAddress>>();
+        .collect::<Vec<ContractId>>();
 
     Transaction::create(
         MAX_GAS_PER_TX,


### PR DESCRIPTION
For a better consistency with the specs, its preferable we keep the same
names in the implementation and the documents.