### PR TITLE
Add Input::coin_predicate_offset

### DIFF
--- a/src/transaction/offset.rs
+++ b/src/transaction/offset.rs
@@ -1,5 +1,6 @@
 use super::{
-    ContractId, Metadata, Transaction, TRANSACTION_CREATE_FIXED_SIZE, TRANSACTION_SCRIPT_FIXED_SIZE,
+    ContractId, Input, Metadata, Transaction, TRANSACTION_CREATE_FIXED_SIZE,
+    TRANSACTION_SCRIPT_FIXED_SIZE,
 };
 use crate::bytes::{self, SizedBytes};
 
@@ -37,17 +38,9 @@ impl Transaction {
     }
 
     pub(crate) fn _input_coin_predicate_offset(&self, index: usize) -> Option<usize> {
-        self.inputs()
-            .get(index)
-            .map(|i| {
-                i.predicate()
-                    .map(|(predicate, data)| (predicate, data, i.serialized_size()))
-            })
-            .flatten()
-            .zip(self.input_offset(index))
-            .map(|((predicate, data, size), offset)| {
-                offset + size - bytes::padded_len(predicate) - bytes::padded_len(data)
-            })
+        self.input_offset(index)
+            .map(|ofs| ofs + Input::coin_predicate_offset())
+            .filter(|_| self.inputs()[index].is_coin())
     }
 
     /// Return the serialized bytes offset of the input with the provided index

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -152,6 +152,27 @@ impl Input {
             _ => None,
         }
     }
+
+    pub const fn is_coin(&self) -> bool {
+        match self {
+            Input::Coin { .. } => true,
+            _ => false,
+        }
+    }
+
+    pub const fn coin_predicate_offset() -> usize {
+        INPUT_COIN_FIXED_SIZE
+    }
+
+    pub fn coin_predicate_data_offset(&self) -> Option<usize> {
+        match self {
+            Input::Coin { predicate, .. } => {
+                Some(Self::coin_predicate_offset() + bytes::padded_len(predicate.as_slice()))
+            }
+
+            _ => None,
+        }
+    }
 }
 
 impl io::Read for Input {


### PR DESCRIPTION
This function is needed to calculate predicate/data offsets before the
transaction is created.

This offset can be trivially calculated after the transaction is
created, but this is not desired considering the transaction is not
expected to be mutable.

This function will replace some eventual new opcodes that will evaluate
the transaction at runtime and will set a register with the desired
offset. The following sequence should be enough to set the offset:

```
XIS(0x10, i)
ADDI(0x10, 0x10, Input::coin_predicate_offset)
```