### PR TITLE
Add seed constant to contract ID

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,10 +1,58 @@
 use crate::Bytes32;
 use sha2::{Digest, Sha256};
 
-pub fn hash(data: &[u8]) -> Bytes32 {
-    let mut hasher = Sha256::new();
+use std::iter;
 
-    hasher.update(data);
+#[derive(Debug, Default, Clone)]
+pub struct Hasher(Sha256);
 
-    <[u8; Bytes32::size_of()]>::from(hasher.finalize()).into()
+impl Hasher {
+    pub fn input<B>(&mut self, data: B)
+    where
+        B: AsRef<[u8]>,
+    {
+        self.0.update(data)
+    }
+
+    pub fn chain<B>(self, data: B) -> Self
+    where
+        B: AsRef<[u8]>,
+    {
+        Self(self.0.chain(data))
+    }
+
+    pub fn reset(&mut self) {
+        self.0.reset();
+    }
+
+    pub fn hash<B>(data: B) -> Bytes32
+    where
+        B: AsRef<[u8]>,
+    {
+        let mut hasher = Sha256::new();
+
+        hasher.update(data);
+
+        <[u8; Bytes32::size_of()]>::from(hasher.finalize()).into()
+    }
+
+    pub fn digest(&self) -> Bytes32 {
+        <[u8; Bytes32::size_of()]>::from(self.0.clone().finalize()).into()
+    }
+}
+
+impl<B> iter::FromIterator<B> for Hasher
+where
+    B: AsRef<[u8]>,
+{
+    fn from_iter<T>(iter: T) -> Self
+    where
+        T: IntoIterator<Item = B>,
+    {
+        let mut hasher = Hasher::default();
+
+        iter.into_iter().for_each(|i| hasher.input(i));
+
+        hasher
+    }
 }

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -1,6 +1,6 @@
 use super::{Bytes32, Input, Metadata, Output, Transaction, Witness};
 use crate::bytes::SerializableVec;
-use crate::crypto;
+use crate::crypto::Hasher;
 
 impl Transaction {
     pub(crate) fn inputs_mut(&mut self) -> &mut [Input] {
@@ -35,7 +35,7 @@ impl Transaction {
         let mut tx = self.clone();
         tx.prepare_sign();
 
-        crypto::hash(tx.to_bytes().as_slice())
+        Hasher::hash(tx.to_bytes().as_slice())
     }
 
     fn prepare_sign(&mut self) {

--- a/src/transaction/types.rs
+++ b/src/transaction/types.rs
@@ -95,3 +95,7 @@ key!(Color, 32);
 key!(ContractId, 32);
 key!(Bytes32, 32);
 key!(Salt, 32);
+
+impl ContractId {
+    pub const SEED: [u8; 4] = 0x4655454C_u32.to_be_bytes();
+}


### PR DESCRIPTION
As discussed in https://github.com/FuelLabs/fuel-vm/pull/11#discussion_r688135644 , the seed used to calculate the contract ID will be exported to all the consumers of `fuel-tx`

A refactor in the crypto hasher function was also added to prevent unnecessary copy/alloc for chunks of bytes to be hashed.