### PR TITLE
Add Bytes64 transaction type

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,6 @@ pub mod consts;
 pub mod crypto;
 
 pub use transaction::{
-    Address, Bytes32, Bytes4, Bytes8, Color, ContractId, Input, Metadata, Output, Salt,
+    Address, Bytes32, Bytes4, Bytes64, Bytes8, Color, ContractId, Input, Metadata, Output, Salt,
     Transaction, ValidationError, Witness,
 };

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -14,7 +14,7 @@ mod validation;
 
 pub use metadata::Metadata;
 pub use types::{
-    Address, Bytes32, Bytes4, Bytes8, Color, ContractId, Input, Output, Salt, Witness,
+    Address, Bytes32, Bytes4, Bytes64, Bytes8, Color, ContractId, Input, Output, Salt, Witness,
 };
 pub use validation::ValidationError;
 


### PR DESCRIPTION
Arrays bigger than 32 bytes won't benefit from default blanket
implementations for Distribution, Default and Serde

Bytes64 requires a dedicated implementation