### PR TITLE
Make `key!`s public for consumers of the API

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -17,7 +17,7 @@ macro_rules! key {
             feature = "serde-types-minimal",
             derive(serde::Serialize, serde::Deserialize)
         )]
-        pub struct $i([u8; $s]);
+        pub struct $i(pub [u8; $s]);
 
         key_methods!($i, $s);
 


### PR DESCRIPTION
In the Sway test harness, I check source code against VM outputs. I would like to be able to check more VM outputs than just returned integers, so I need to check data returns as well. Unfortunately:
```
error[E0423]: cannot initialize a tuple struct which contains private fields
   --> test/src/e2e_vm_tests/mod.rs:23:38
    |
23  |             ProgramState::ReturnData(Bytes32([
    |                                      ^^^^^^^
    |
note: constructor is not visible here due to private fields
   --> /Users/alexanderhansen/.cargo/git/checkouts/fuel-tx-15ba46c1f907ce49/c4e5e58/src/types.rs:160:1
    |
160 | key!(Bytes32, 32);
    | ^^^^^^^^^^^^^^^^^^ private field
    = note: this error originates in the macro `key` (in Nightly builds, run with -Z macro-backtrace for more info)
```