### PR TITLE
Add `fuel-types` dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,18 +10,18 @@ description = "FuelVM transaction."
 
 [dependencies]
 fuel-asm = { git = "ssh://git@github.com/FuelLabs/fuel-asm.git", default-features = false }
-fuel-data = { git = "ssh://git@github.com/FuelLabs/fuel-data.git", default-features = false }
+fuel-types = { git = "ssh://git@github.com/FuelLabs/fuel-types.git", default-features = false }
 itertools = { version = "0.10", optional = true }
 rand = { version = "0.8", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 sha2 = { version = "0.9", optional = true }
 
 [features]
-default = [ "fuel-asm/default", "fuel-data/default", "std" ]
-random = [ "fuel-data/random" ]
-std = [ "fuel-asm/std", "fuel-data/std", "itertools", "rand", "sha2" ]
-serde-types = [ "fuel-asm/serde-types", "fuel-data/serde-types", "serde-types-minimal", "serde/default", "std" ]
-serde-types-minimal = [ "fuel-asm/serde-types-minimal", "fuel-data/serde-types-minimal", "serde" ]
+default = [ "fuel-asm/default", "fuel-types/default", "std" ]
+random = [ "fuel-types/random" ]
+std = [ "fuel-asm/std", "fuel-types/std", "itertools", "rand", "sha2" ]
+serde-types = [ "fuel-asm/serde-types", "fuel-types/serde-types", "serde-types-minimal", "serde/default", "std" ]
+serde-types-minimal = [ "fuel-asm/serde-types-minimal", "fuel-types/serde-types-minimal", "serde" ]
 
 [[test]]
 name = "test-bytes"

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,4 +1,4 @@
-use fuel_data::Bytes32;
+use fuel_types::Bytes32;
 use sha2::{Digest, Sha256};
 
 use std::iter;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 
 pub mod consts;
 
-pub use fuel_data::{Address, Bytes32, Bytes4, Bytes64, Bytes8, Color, ContractId, Salt};
+pub use fuel_types::{Address, Bytes32, Bytes4, Bytes64, Bytes8, Color, ContractId, Salt};
 
 #[cfg(feature = "std")]
 pub mod crypto;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,5 +1,5 @@
 use fuel_asm::Opcode;
-use fuel_data::{Bytes32, Color, ContractId, Salt, Word};
+use fuel_types::{Bytes32, Color, ContractId, Salt, Word};
 use itertools::Itertools;
 
 use std::convert::TryFrom;

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -1,8 +1,8 @@
 use crate::crypto::Hasher;
 use crate::{Input, Metadata, Output, Transaction, Witness};
 
-use fuel_data::bytes::SerializableVec;
-use fuel_data::Bytes32;
+use fuel_types::bytes::SerializableVec;
+use fuel_types::Bytes32;
 
 impl Transaction {
     pub(crate) fn inputs_mut(&mut self) -> &mut [Input] {

--- a/src/transaction/metadata.rs
+++ b/src/transaction/metadata.rs
@@ -1,7 +1,7 @@
 use crate::Transaction;
 
-use fuel_data::bytes::SizedBytes;
-use fuel_data::Bytes32;
+use fuel_types::bytes::SizedBytes;
+use fuel_types::Bytes32;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(

--- a/src/transaction/offset.rs
+++ b/src/transaction/offset.rs
@@ -1,8 +1,8 @@
 use super::{TRANSACTION_CREATE_FIXED_SIZE, TRANSACTION_SCRIPT_FIXED_SIZE};
 use crate::{Input, Metadata, Transaction};
 
-use fuel_data::bytes::{self, SizedBytes};
-use fuel_data::ContractId;
+use fuel_types::bytes::{self, SizedBytes};
+use fuel_types::ContractId;
 
 impl Transaction {
     /// For a serialized transaction of type `Script`, return the bytes offset

--- a/src/transaction/receipt.rs
+++ b/src/transaction/receipt.rs
@@ -1,5 +1,5 @@
-use fuel_data::bytes::{self, SizedBytes};
-use fuel_data::{Address, Bytes32, Color, ContractId, Word};
+use fuel_types::bytes::{self, SizedBytes};
+use fuel_types::{Address, Bytes32, Color, ContractId, Word};
 
 use std::convert::TryFrom;
 use std::io::{self, Write};

--- a/src/transaction/txio.rs
+++ b/src/transaction/txio.rs
@@ -1,8 +1,8 @@
 use super::{TransactionRepr, TRANSACTION_CREATE_FIXED_SIZE, TRANSACTION_SCRIPT_FIXED_SIZE};
 use crate::{Input, Output, Transaction, Witness};
 
-use fuel_data::bytes::{self, SizedBytes};
-use fuel_data::{ContractId, Word};
+use fuel_types::bytes::{self, SizedBytes};
+use fuel_types::{ContractId, Word};
 
 use std::convert::TryFrom;
 use std::{io, mem};

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -1,5 +1,5 @@
-use fuel_data::bytes::{self, SizedBytes};
-use fuel_data::{Address, Bytes32, Color, ContractId, Word};
+use fuel_types::bytes::{self, SizedBytes};
+use fuel_types::{Address, Bytes32, Color, ContractId, Word};
 
 use std::convert::TryFrom;
 use std::{io, mem};

--- a/src/transaction/types/output.rs
+++ b/src/transaction/types/output.rs
@@ -1,5 +1,5 @@
-use fuel_data::bytes::{self, SizedBytes};
-use fuel_data::{Address, Bytes32, Color, ContractId, Word};
+use fuel_types::bytes::{self, SizedBytes};
+use fuel_types::{Address, Bytes32, Color, ContractId, Word};
 
 use std::convert::TryFrom;
 use std::{io, mem};

--- a/src/transaction/types/witness.rs
+++ b/src/transaction/types/witness.rs
@@ -1,4 +1,4 @@
-use fuel_data::{bytes, Word};
+use fuel_types::{bytes, Word};
 
 use rand::distributions::{Distribution, Standard};
 use rand::Rng;

--- a/src/transaction/validation.rs
+++ b/src/transaction/validation.rs
@@ -1,7 +1,7 @@
 use crate::consts::*;
 use crate::{Input, Output, Transaction, Witness};
 
-use fuel_data::{Color, Word};
+use fuel_types::{Color, Word};
 
 mod error;
 

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,5 +1,5 @@
-use fuel_data::{bytes, ContractId};
 use fuel_tx::*;
+use fuel_types::{bytes, ContractId};
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
 use std::fmt;

--- a/tests/offset_cases/factory.rs
+++ b/tests/offset_cases/factory.rs
@@ -1,5 +1,5 @@
-use fuel_data::bytes::Deserializable;
 use fuel_tx::*;
+use fuel_types::bytes::Deserializable;
 use rand::distributions::{Distribution, Uniform};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};

--- a/tests/offset_cases/mod.rs
+++ b/tests/offset_cases/mod.rs
@@ -1,5 +1,5 @@
-use fuel_data::bytes::{Deserializable, SerializableVec};
 use fuel_tx::*;
+use fuel_types::bytes::{Deserializable, SerializableVec};
 
 mod factory;
 

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -1,6 +1,6 @@
-use fuel_data::*;
 use fuel_tx::consts::*;
 use fuel_tx::*;
+use fuel_types::*;
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
 


### PR DESCRIPTION
`fuel-types` is the default provider of the infrastructure common types.