### PR TITLE
Add `extend_chain` method to `Hasher`

### DIFF
--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -21,6 +21,16 @@ impl Hasher {
         Self(self.0.chain(data))
     }
 
+    pub fn extend_chain<B, I>(mut self, iter: I) -> Self
+    where
+        B: AsRef<[u8]>,
+        I: IntoIterator<Item = B>,
+    {
+        self.extend(iter);
+
+        self
+    }
+
     pub fn reset(&mut self) {
         self.0.reset();
     }


### PR DESCRIPTION
Current `Extend` trait of Rust doesn't support builder-like
implementations.

Hence, we need an explicit method for the `Hasher`