### PR TITLE
Replace `ScriptResultRepr` by `PanicReason`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,4 +24,4 @@ mod receipt;
 pub use transaction::{Input, Metadata, Output, Transaction, ValidationError, Witness};
 
 #[cfg(feature = "std")]
-pub use receipt::{Receipt, ScriptResult, ScriptResultRepr};
+pub use receipt::{PanicReason, Receipt, ScriptResult};

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -5,12 +5,12 @@ use std::convert::TryFrom;
 use std::io::{self, Write};
 use std::mem;
 
+mod panic_reason;
 mod receipt_repr;
-mod script_result;
 
 use receipt_repr::ReceiptRepr;
 
-pub use script_result::{ScriptResult, ScriptResultRepr};
+pub use panic_reason::{PanicReason, ScriptResult};
 
 const WORD_SIZE: usize = mem::size_of::<Word>();
 

--- a/src/receipt/panic_reason.rs
+++ b/src/receipt/panic_reason.rs
@@ -7,7 +7,7 @@ const WORD_SIZE: usize = mem::size_of::<Word>();
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
-pub enum ScriptResultRepr {
+pub enum PanicReason {
     Success = 0x00,
     Revert = 0x01,
     OutOfGas = 0x02,
@@ -42,13 +42,13 @@ pub enum ScriptResultRepr {
     InvalidRepresentation = 0xff,
 }
 
-impl From<ScriptResultRepr> for Word {
-    fn from(r: ScriptResultRepr) -> Word {
+impl From<PanicReason> for Word {
+    fn from(r: PanicReason) -> Word {
         r as Word
     }
 }
 
-impl From<Word> for ScriptResultRepr {
+impl From<Word> for PanicReason {
     fn from(b: Word) -> Self {
         match b {
             0x00 => Self::Success,
@@ -90,19 +90,19 @@ impl From<Word> for ScriptResultRepr {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 #[cfg_attr(feature = "serde-types", derive(serde::Serialize, serde::Deserialize))]
 pub struct ScriptResult {
-    result: ScriptResultRepr,
+    result: PanicReason,
     instruction: Instruction,
 }
 
 impl ScriptResult {
-    pub const fn new(result: ScriptResultRepr, instruction: Instruction) -> Self {
+    pub const fn new(result: PanicReason, instruction: Instruction) -> Self {
         Self {
             result,
             instruction,
         }
     }
 
-    pub const fn result(&self) -> &ScriptResultRepr {
+    pub const fn result(&self) -> &PanicReason {
         &self.result
     }
 
@@ -125,7 +125,7 @@ impl From<ScriptResult> for Word {
 
 impl From<Word> for ScriptResult {
     fn from(val: Word) -> Self {
-        let result = ScriptResultRepr::from(val >> RESULT_OFFSET);
+        let result = PanicReason::from(val >> RESULT_OFFSET);
         let instruction = Instruction::from((val >> INSTR_OFFSET) as u32);
 
         Self::new(result, instruction)
@@ -144,7 +144,7 @@ impl From<ScriptResult> for Opcode {
     }
 }
 
-impl From<ScriptResult> for ScriptResultRepr {
+impl From<ScriptResult> for PanicReason {
     fn from(r: ScriptResult) -> Self {
         r.result
     }

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -203,217 +203,217 @@ fn receipt() {
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::Success,
+                PanicReason::Success,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::Revert,
+                PanicReason::Revert,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::OutOfGas,
+                PanicReason::OutOfGas,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::TransactionValidity,
+                PanicReason::TransactionValidity,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::MemoryOverflow,
+                PanicReason::MemoryOverflow,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ArithmeticOverflow,
+                PanicReason::ArithmeticOverflow,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ContractNotFound,
+                PanicReason::ContractNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::MemoryOwnership,
+                PanicReason::MemoryOwnership,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::NotEnoughBalance,
+                PanicReason::NotEnoughBalance,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ExpectedInternalContext,
+                PanicReason::ExpectedInternalContext,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ColorNotFound,
+                PanicReason::ColorNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::InputNotFound,
+                PanicReason::InputNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::OutputNotFound,
+                PanicReason::OutputNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::WitnessNotFound,
+                PanicReason::WitnessNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::TransactionMaturity,
+                PanicReason::TransactionMaturity,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::InvalidMetadataIdentifier,
+                PanicReason::InvalidMetadataIdentifier,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::MalformedCallStructure,
+                PanicReason::MalformedCallStructure,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ReservedRegisterNotWritable,
+                PanicReason::ReservedRegisterNotWritable,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ErrorFlag,
+                PanicReason::ErrorFlag,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::InvalidImmediateValue,
+                PanicReason::InvalidImmediateValue,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ExpectedCoinInput,
+                PanicReason::ExpectedCoinInput,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::MaxMemoryAccess,
+                PanicReason::MaxMemoryAccess,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::MemoryWriteOverlap,
+                PanicReason::MemoryWriteOverlap,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ContractNotInInputs,
+                PanicReason::ContractNotInInputs,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::InternalBalanceOverflow,
+                PanicReason::InternalBalanceOverflow,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ContractMaxSize,
+                PanicReason::ContractMaxSize,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ExpectedUnallocatedStack,
+                PanicReason::ExpectedUnallocatedStack,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::MaxStaticContractsReached,
+                PanicReason::MaxStaticContractsReached,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::TransferAmountCannotBeZero,
+                PanicReason::TransferAmountCannotBeZero,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ExpectedOutputVariable,
+                PanicReason::ExpectedOutputVariable,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
         ),
         Receipt::script_result(
             ScriptResult::new(
-                ScriptResultRepr::ExpectedParentInternalContext,
+                PanicReason::ExpectedParentInternalContext,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),


### PR DESCRIPTION
The specs refer to what is implemented as script result representation
as `PanicReason`.

This panic reason can be used also outside script execution (Predicate
verification?) since the instructions execution will be the same for
both.

Using `ScriptResultRepr` for predicate verification is misleading.