### PR TITLE
Adjust overly restrictive feature flags on tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,9 @@ rand = { version = "0.8", optional = true }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 sha2 = { version = "0.9", optional = true }
 
+[dev-dependencies]
+fuel-types = { git = "ssh://git@github.com/FuelLabs/fuel-types.git", default-features = false, features = ["random"] }
+
 [features]
 default = ["fuel-asm/default", "fuel-types/default", "std"]
 random = ["fuel-types/random"]
@@ -26,14 +29,14 @@ serde-types-minimal = ["fuel-asm/serde-types-minimal", "fuel-types/serde-types-m
 [[test]]
 name = "test-bytes"
 path = "tests/bytes.rs"
-required-features = ["random", "std"]
+required-features = ["std"]
 
 [[test]]
 name = "test-offsets"
 path = "tests/offset.rs"
-required-features = ["random", "std"]
+required-features = ["std"]
 
 [[test]]
 name = "test-valid"
 path = "tests/valid.rs"
-required-features = ["random", "std"]
+required-features = ["std"]


### PR DESCRIPTION
Tests weren't able to properly run without manually specifying the `random` feature flag. This uses the new cargo resolver to automatically enable the random feature on `fuel-types` in tests.