### PR TITLE
UtxoId compilation fixes + feature flag updates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,8 +24,8 @@ fuel-tx = { path = ".", features = ["random"]}
 
 [features]
 default = ["fuel-asm/default", "fuel-types/default", "std"]
-random = ["fuel-types/random"]
-std = ["fuel-asm/std", "fuel-types/std", "itertools", "rand", "sha2"]
+random = ["fuel-types/random", "rand"]
+std = ["fuel-asm/std", "fuel-types/std", "itertools", "sha2"]
 serde-types = ["fuel-asm/serde-types", "fuel-types/serde-types", "serde-types-minimal", "serde/default", "std"]
 serde-types-minimal = ["fuel-asm/serde-types-minimal", "fuel-types/serde-types-minimal", "serde"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ sha2 = { version = "0.9", optional = true }
 
 [dev-dependencies]
 fuel-types = { version = "0.1", default-features = false, features = ["random"] }
+fuel-tx = { path = ".", features = ["random"]}
 
 [features]
 default = ["fuel-asm/default", "fuel-types/default", "std"]

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -99,6 +99,16 @@ mod tests {
         bytes.as_mut().iter_mut().for_each(|b| *b = b.not());
     }
 
+    fn invert_utxo_id(utxo_id: &mut UtxoId) {
+        let mut tx_id = utxo_id.tx_id().clone();
+        let mut out_idx = [utxo_id.output_index()];
+
+        invert(&mut tx_id);
+        invert(&mut out_idx);
+
+        *utxo_id = UtxoId::new(tx_id, out_idx[0])
+    }
+
     fn inv_v(bytes: &mut Vec<u8>) {
         if bytes.is_empty() {
             bytes.push(0xfb);
@@ -173,7 +183,7 @@ mod tests {
         assert_id_ne(tx, |t| t.set_maturity(t.maturity().not()));
 
         if !tx.inputs().is_empty() {
-            assert_io_ne!(tx, inputs_mut, Input::Coin, utxo_id, invert);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, utxo_id, invert_utxo_id);
             assert_io_ne!(tx, inputs_mut, Input::Coin, owner, invert);
             assert_io_ne!(tx, inputs_mut, Input::Coin, amount, not);
             assert_io_ne!(tx, inputs_mut, Input::Coin, color, invert);
@@ -182,7 +192,7 @@ mod tests {
             assert_io_ne!(tx, inputs_mut, Input::Coin, predicate, inv_v);
             assert_io_ne!(tx, inputs_mut, Input::Coin, predicate_data, inv_v);
 
-            assert_io_eq!(tx, inputs_mut, Input::Contract, utxo_id, invert);
+            assert_io_eq!(tx, inputs_mut, Input::Contract, utxo_id, invert_utxo_id);
             assert_io_eq!(tx, inputs_mut, Input::Contract, balance_root, invert);
             assert_io_eq!(tx, inputs_mut, Input::Contract, state_root, invert);
             assert_io_ne!(tx, inputs_mut, Input::Contract, contract_id, invert);

--- a/src/transaction/types/utxo_id.rs
+++ b/src/transaction/types/utxo_id.rs
@@ -2,6 +2,7 @@ use std::str::FromStr;
 
 use crate::TxId;
 use fuel_types::Bytes32;
+#[cfg(feature = "random")]
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
@@ -37,6 +38,7 @@ impl UtxoId {
     }
 }
 
+#[cfg(feature = "random")]
 impl Distribution<UtxoId> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> UtxoId {
         let mut tx_id = Bytes32::default();

--- a/src/transaction/types/witness.rs
+++ b/src/transaction/types/witness.rs
@@ -1,7 +1,9 @@
 use fuel_types::{bytes, Word};
-
-use rand::distributions::{Distribution, Standard};
-use rand::Rng;
+#[cfg(feature = "random")]
+use rand::{
+    distributions::{Distribution, Standard},
+    Rng,
+};
 use std::{io, mem};
 
 const WORD_SIZE: usize = mem::size_of::<Word>();
@@ -59,6 +61,7 @@ impl Extend<u8> for Witness {
     }
 }
 
+#[cfg(feature = "random")]
 impl Distribution<Witness> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Witness {
         let len = rng.gen_range(0..512);


### PR DESCRIPTION
Due to the use of various feature flags, some of the transaction id tests weren't being covered by our existing CI configuration.

Enabling all the tests caused some compile errors due to the new UtxoId structure. This PR fixes those and also adjusts the feature flag configuration to avoid this situation in the future. 

It also moved rand behind the random feature, since these functions aren't intended for standard usage (they are just test helpers).