### PR TITLE
Exclude witness data from transaction id

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -256,6 +256,13 @@ impl Transaction {
         }
     }
 
+    pub fn set_witnesses(&mut self, new_witnesses: Vec<Witness>) {
+        match self {
+            Self::Script { witnesses, .. } => *witnesses = new_witnesses,
+            Self::Create { witnesses, .. } => *witnesses = new_witnesses,
+        }
+    }
+
     pub fn try_from_bytes(bytes: &[u8]) -> io::Result<(usize, Self)> {
         let mut tx = Self::default();
 

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -42,6 +42,7 @@ impl Transaction {
 
     fn prepare_sign(&mut self) {
         self.set_receipts_root(Default::default());
+        self.set_witnesses(vec![]);
 
         self.inputs_mut().iter_mut().for_each(|input| {
             if let Input::Contract {
@@ -229,7 +230,7 @@ mod tests {
         }
 
         if !tx.witnesses().is_empty() {
-            assert_id_ne(tx, |t| {
+            assert_id_eq(tx, |t| {
                 inv_v(t.witnesses_mut().first_mut().unwrap().as_vec_mut())
             });
         }


### PR DESCRIPTION
Witness data shouldn't be included as part of the transaction id, otherwise signed txs will never match the unsigned version.

closes #62