### PR TITLE
Increase the maximum contract size to 16 MiB.

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,5 +1,5 @@
 /// Maximum contract size, in bytes.
-pub const CONTRACT_MAX_SIZE: u64 = 16 * 1024;
+pub const CONTRACT_MAX_SIZE: u64 = 16 * 1024 * 1024;
 
 /// Maximum number of inputs.
 pub const MAX_INPUTS: u8 = 8;


### PR DESCRIPTION
The 16 KiB limit is too low in general, and was also resulting in failing tests etc. due to lack of compiler optimizations (but would be hit eventually anyways even with optimizations).