### PR TITLE
add accessors to StorageSlot

### DIFF
--- a/src/transaction/types/storage.rs
+++ b/src/transaction/types/storage.rs
@@ -20,6 +20,14 @@ impl StorageSlot {
     pub fn new(key: Bytes32, value: Bytes32) -> Self {
         StorageSlot { key, value }
     }
+
+    pub fn key(&self) -> Bytes32 {
+        self.key
+    }
+
+    pub fn value(&self) -> Bytes32 {
+        self.value
+    }
 }
 
 #[cfg(feature = "random")]

--- a/src/transaction/types/storage.rs
+++ b/src/transaction/types/storage.rs
@@ -21,12 +21,12 @@ impl StorageSlot {
         StorageSlot { key, value }
     }
 
-    pub fn key(&self) -> Bytes32 {
-        self.key
+    pub fn key(&self) -> &Bytes32 {
+        &self.key
     }
 
-    pub fn value(&self) -> Bytes32 {
-        self.value
+    pub fn value(&self) -> &Bytes32 {
+        &self.value
     }
 }
 


### PR DESCRIPTION
I realized we'll need accessors to retrieve the storage slot fields in downstream crates. 