### PR TITLE
add state_root field to contract created output

### DIFF
--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -276,7 +276,7 @@ mod tests {
                 Output::withdrawal(rng.gen(), rng.next_u64(), rng.gen()),
                 Output::change(rng.gen(), rng.next_u64(), rng.gen()),
                 Output::variable(rng.gen(), rng.next_u64(), rng.gen()),
-                Output::contract_created(rng.gen()),
+                Output::contract_created(rng.gen(), rng.gen()),
             ],
         ];
 

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -137,7 +137,7 @@ fn output() {
         Output::withdrawal(rng.gen(), rng.next_u64(), rng.gen()),
         Output::change(rng.gen(), rng.next_u64(), rng.gen()),
         Output::variable(rng.gen(), rng.next_u64(), rng.gen()),
-        Output::contract_created(rng.gen()),
+        Output::contract_created(rng.gen(), rng.gen()),
     ]);
 }
 

--- a/tests/offset_cases/factory.rs
+++ b/tests/offset_cases/factory.rs
@@ -52,7 +52,7 @@ impl TransactionFactory {
             2 => Output::withdrawal(self.rng.gen(), self.rng.gen(), self.rng.gen()),
             3 => Output::change(self.rng.gen(), self.rng.gen(), self.rng.gen()),
             4 => Output::variable(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-            5 => Output::contract_created(self.rng.gen()),
+            5 => Output::contract_created(self.rng.gen(), self.rng.gen()),
 
             _ => unreachable!(),
         }

--- a/tests/valid_cases/output.rs
+++ b/tests/valid_cases/output.rs
@@ -114,7 +114,7 @@ fn contract_created() {
     let mut rng_base = StdRng::seed_from_u64(8586);
     let rng = &mut rng_base;
 
-    Output::contract_created(rng.gen())
+    Output::contract_created(rng.gen(), rng.gen())
         .validate(1, &[])
         .unwrap();
 }

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -406,7 +406,7 @@ fn script() {
             rng.gen::<Witness>().into_inner(),
             rng.gen::<Witness>().into_inner(),
         )],
-        vec![Output::contract_created(rng.gen())],
+        vec![Output::contract_created(rng.gen(), rng.gen())],
         vec![rng.gen()],
     )
     .validate(block_height)
@@ -434,7 +434,7 @@ fn script() {
             rng.gen::<Witness>().into_inner(),
             rng.gen::<Witness>().into_inner(),
         )],
-        vec![Output::contract_created(rng.gen())],
+        vec![Output::contract_created(rng.gen(), rng.gen())],
         vec![rng.gen()],
     )
     .validate(block_height)
@@ -674,8 +674,8 @@ fn create() {
             ),
         ],
         vec![
-            Output::contract_created(rng.gen()),
-            Output::contract_created(rng.gen()),
+            Output::contract_created(rng.gen(), rng.gen()),
+            Output::contract_created(rng.gen(), rng.gen()),
         ],
         vec![rng.gen()],
     )


### PR DESCRIPTION
Add the state root field as specified in https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/tx_format.md#outputcontractcreated

This was missing from the last release which added initial storage slots to create txs.