### PR TITLE
feat: improve error logging for invalid identifiers

### DIFF
--- a/src/receipt/receipt_repr.rs
+++ b/src/receipt/receipt_repr.rs
@@ -49,9 +49,9 @@ impl TryFrom<Word> for ReceiptRepr {
             0x07 => Ok(Self::Transfer),
             0x08 => Ok(Self::TransferOut),
             0x09 => Ok(Self::ScriptResult),
-            _ => Err(io::Error::new(
+            i => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "The provided identifier is invalid!",
+                format!("The provided receipt identifier ({}) is invalid!", i),
             )),
         }
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -62,9 +62,9 @@ impl TryFrom<Word> for TransactionRepr {
         match b {
             0x00 => Ok(Self::Script),
             0x01 => Ok(Self::Create),
-            _ => Err(io::Error::new(
+            i => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "The provided identifier is invalid!",
+                format!("The provided transaction identifier ({}) is invalid!", i),
             )),
         }
     }

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -38,9 +38,9 @@ impl TryFrom<Word> for InputRepr {
         match b {
             0x00 => Ok(Self::Coin),
             0x01 => Ok(Self::Contract),
-            _ => Err(io::Error::new(
+            id => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "The provided identifier is invalid!",
+                format!("The provided input identifier ({}) is invalid!", id),
             )),
         }
     }

--- a/src/transaction/types/output.rs
+++ b/src/transaction/types/output.rs
@@ -41,9 +41,9 @@ impl TryFrom<Word> for OutputRepr {
             0x03 => Ok(Self::Change),
             0x04 => Ok(Self::Variable),
             0x05 => Ok(Self::ContractCreated),
-            _ => Err(io::Error::new(
+            i => Err(io::Error::new(
                 io::ErrorKind::InvalidData,
-                "The provided identifier is invalid!",
+                format!("The provided output identifier ({}) is invalid!", i),
             )),
         }
     }


### PR DESCRIPTION
This PR improves the logging for invalid identifiers errors, by specifying where they arrive.
This closes issue #80.
