### PR TITLE
Fix variable output validation rule

### DIFF
--- a/src/transaction/validation.rs
+++ b/src/transaction/validation.rs
@@ -192,20 +192,6 @@ impl Transaction {
                     return Err(ValidationError::TransactionOutputChangeAssetIdDuplicated);
                 }
 
-                // check for duplicate variable outputs
-                if self
-                    .outputs()
-                    .iter()
-                    .filter_map(|output| match output {
-                        Output::Variable { asset_id, .. } if input_asset_id == asset_id => Some(()),
-                        _ => None,
-                    })
-                    .count()
-                    > 1
-                {
-                    return Err(ValidationError::TransactionOutputVariableAssetIdDuplicated);
-                }
-
                 Ok(())
             })?;
 

--- a/src/transaction/validation/error.rs
+++ b/src/transaction/validation/error.rs
@@ -36,6 +36,7 @@ pub enum ValidationError {
     TransactionWitnessesMax,
     TransactionOutputChangeAssetIdDuplicated,
     TransactionOutputChangeAssetIdNotFound,
+    // TODO: remove in future breaking change to this library
     TransactionOutputVariableAssetIdDuplicated,
 }
 


### PR DESCRIPTION
Due to my lack of understanding of variable outputs when initially implementing them, I implemented a validation rule preventing duplicate asset_id's thinking that variable outputs would behave more like change outputs. However, it is perfectly normal for variable outputs to share asset_id's, and they shouldn't be validated from a user input perspective since they're considered to be zeroed out initially.

I'm not removing the error variant from the validation enum yet, as this would create a breaking change to the Rust API and prevent the ability release this fix as a patch.