### PR TITLE
split fuel-tx CI into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,109 +12,216 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
-  build:
+  cancel-previous-runs:
     runs-on: ubuntu-latest
-
     steps:
-    - name: Cancel Previous Runs
-      uses: styfle/cancel-workflow-action@0.9.1
-      with:
-        access_token: ${{ github.token }}
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.9.1
+        with:
+          access_token: ${{ github.token }}
 
-    - name: Checkout repository
-      uses: actions/checkout@v2
+  cargo-fmt-check:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - name: Check Formatting
+        uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all --verbose -- --check
 
-    - name: Install toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        profile: minimal
-        toolchain: stable
-        override: true
+  cargo-clippy:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Check Clippy Linter
+        uses: actions-rs/cargo@v1
+        with:
+          command: clippy
+          args: --all-features --all-targets -- -D warnings
 
+  cargo-check:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --verbose
 
-    # Using thumbv6m-none-eabi as ARMv6-M arbitrary common choice for a bare-minimum target.
-    # More info: https://docs.rs/cortex-m-rt/latest/cortex_m_rt/
-    #
-    # Can be replaced by other targets that guarantee bare-minimum no-std
-    - name: Install toolchain no-std
-      uses: actions-rs/toolchain@v1
-      with:
-        toolchain: stable
-        target: thumbv6m-none-eabi
-        override: true
+  cargo-check-no-std:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          # Using thumbv6m-none-eabi as ARMv6-M arbitrary common choice for a bare-minimum target.
+          # More info: https://docs.rs/cortex-m-rt/latest/cortex_m_rt/
+          #
+          # Can be replaced by other targets that guarantee bare-minimum no-std
+          target: thumbv6m-none-eabi
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --verbose --target thumbv6m-none-eabi --no-default-features
 
-    - name: Install rustfmt
-      run: rustup component add rustfmt
+  cargo-check-no-std-alloc:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          # Using thumbv6m-none-eabi as ARMv6-M arbitrary common choice for a bare-minimum target.
+          # More info: https://docs.rs/cortex-m-rt/latest/cortex_m_rt/
+          #
+          # Can be replaced by other targets that guarantee bare-minimum no-std
+          target: thumbv6m-none-eabi
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --verbose --target thumbv6m-none-eabi --no-default-features --features alloc
 
-    - name: Check formatting
-      uses: actions-rs/cargo@v1
-      with:
-        command: fmt
-        args: --all --verbose -- --check
+  cargo-check-no-std-serde:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          # Using thumbv6m-none-eabi as ARMv6-M arbitrary common choice for a bare-minimum target.
+          # More info: https://docs.rs/cortex-m-rt/latest/cortex_m_rt/
+          #
+          # Can be replaced by other targets that guarantee bare-minimum no-std
+          target: thumbv6m-none-eabi
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: check
+          args: --verbose --target thumbv6m-none-eabi --no-default-features --features serde-types-minimal
 
-    - name: Check Clippy Lints
-      uses: actions-rs/cargo@v1
-      with:
-        command: clippy
-        args: --verbose --all-targets
+  cargo-test:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --all --all-features
 
-    - name: Build
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose
+  cargo-test-no-std:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --no-default-features
 
-    - name: Build no-std
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose --target thumbv6m-none-eabi --no-default-features
+  cargo-test-no-std-serde:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --no-default-features --features serde-types-minimal
 
-    - name: Build no-std alloc
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose --target thumbv6m-none-eabi --no-default-features --features alloc
+  cargo-test-alloc:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --no-default-features --features alloc
 
-    - name: Build no-std serde
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --verbose --target thumbv6m-none-eabi --no-default-features --features serde-types-minimal
-
-    - name: Run tests
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --all --all-features
-
-    - name: Run tests no-std
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --no-default-features
-
-    - name: Run tests serde no-std
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --no-default-features --features serde-types-minimal
-
-    - name: Run tests alloc
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --no-default-features --features alloc
-
-    - name: Run tests serde
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --verbose --features serde-types
+  cargo-test-serde:
+    needs: cancel-previous-runs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+      - uses: Swatinem/rust-cache@v1
+      - name: Run tests
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose --features serde-types
 
   publish:
     # Only do this job if publishing a release
-    needs: build
+    needs:
+      - cargo-fmt-check
+      - cargo-clippy
+      - cargo-check
+      - cargo-check-no-std
+      - cargo-check-no-std-alloc
+      - cargo-check-no-std-serde
+      - cargo-test
+      - cargo-test-no-std
+      - cargo-test-no-std-serde
+      - cargo-test-alloc
+      - cargo-test-serde
     if: github.event_name == 'release' && github.event.action == 'published'
     runs-on: ubuntu-latest
 

--- a/tests/valid_cases/input.rs
+++ b/tests/valid_cases/input.rs
@@ -26,6 +26,7 @@ fn coin() {
             })
     }
 
+    #[allow(clippy::too_many_arguments)]
     fn sign_coin_and_validate<R, I>(
         rng: &mut R,
         mut iter: I,

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -950,33 +950,28 @@ fn create() {
     assert_eq!(ValidationError::TransactionCreateStorageSlotMax, err);
 
     // Test storage slots must be sorted correctly
-    let mut storage_slots_reverse = storage_slots.clone();
+    let mut storage_slots_reverse = storage_slots;
 
     storage_slots_reverse.reverse();
 
-    let err = TransactionBuilder::create(
-        0,
-        rng.gen(),
-        static_contracts.clone(),
-        storage_slots_reverse,
-    )
-    .gas_limit(MAX_GAS_PER_TX)
-    .gas_price(rng.gen())
-    .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
-    .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
-    .finalize()
-    .validate(block_height)
-    .err()
-    .expect("Expected erroneous transaction");
+    let err = TransactionBuilder::create(0, rng.gen(), static_contracts, storage_slots_reverse)
+        .gas_limit(MAX_GAS_PER_TX)
+        .gas_price(rng.gen())
+        .maturity(maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
+        .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
+        .finalize()
+        .validate(block_height)
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionCreateStorageSlotOrder, err);
 }


### PR DESCRIPTION
Parallelizing the CI jobs since the tests take so long to run, this is also because we rerun the tests several times with different feature flags enabled.