### PR TITLE
Receipt Error Improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ mod transaction;
 pub use builder::TransactionBuilder;
 
 #[cfg(feature = "alloc")]
-pub use receipt::Receipt;
+pub use receipt::{Receipt, ScriptExecutionResult};
 
 #[cfg(feature = "alloc")]
 pub use transaction::{

--- a/src/receipt.rs
+++ b/src/receipt.rs
@@ -8,8 +8,11 @@ use alloc::vec::Vec;
 mod receipt_std;
 
 mod receipt_repr;
+mod script_result;
 
 use receipt_repr::ReceiptRepr;
+
+pub use script_result::ScriptExecutionResult;
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(
@@ -48,7 +51,7 @@ pub enum Receipt {
 
     Panic {
         id: ContractId,
-        reason: Word,
+        reason: InstructionResult,
         pc: Word,
         is: Word,
     },
@@ -101,7 +104,7 @@ pub enum Receipt {
     },
 
     ScriptResult {
-        result: InstructionResult,
+        result: ScriptExecutionResult,
         gas_used: Word,
     },
 }
@@ -156,7 +159,7 @@ impl Receipt {
         }
     }
 
-    pub const fn panic(id: ContractId, reason: Word, pc: Word, is: Word) -> Self {
+    pub const fn panic(id: ContractId, reason: InstructionResult, pc: Word, is: Word) -> Self {
         Self::Panic { id, reason, pc, is }
     }
 
@@ -244,7 +247,7 @@ impl Receipt {
         }
     }
 
-    pub const fn script_result(result: InstructionResult, gas_used: Word) -> Self {
+    pub const fn script_result(result: ScriptExecutionResult, gas_used: Word) -> Self {
         Self::ScriptResult { result, gas_used }
     }
 
@@ -394,7 +397,7 @@ impl Receipt {
         }
     }
 
-    pub const fn reason(&self) -> Option<Word> {
+    pub const fn reason(&self) -> Option<InstructionResult> {
         match self {
             Self::Panic { reason, .. } => Some(*reason),
             _ => None,
@@ -432,7 +435,7 @@ impl Receipt {
         }
     }
 
-    pub const fn result(&self) -> Option<&InstructionResult> {
+    pub const fn result(&self) -> Option<&ScriptExecutionResult> {
         match self {
             Self::ScriptResult { result, .. } => Some(result),
             _ => None,

--- a/src/receipt/receipt_std.rs
+++ b/src/receipt/receipt_std.rs
@@ -347,7 +347,7 @@ impl io::Write for Receipt {
 
                 let result = ScriptExecutionResult::from(result);
 
-                *self = Self::script_result(result.into(), gas_used);
+                *self = Self::script_result(result, gas_used);
             }
         }
 

--- a/src/receipt/receipt_std.rs
+++ b/src/receipt/receipt_std.rs
@@ -170,7 +170,7 @@ impl io::Read for Receipt {
             Self::ScriptResult { result, gas_used } => {
                 let buf = bytes::store_number_unchecked(buf, ReceiptRepr::ScriptResult as Word);
 
-                let result: Word = (*result).into();
+                let result = Word::from(*result);
                 let buf = bytes::store_number_unchecked(buf, result);
 
                 bytes::store_number_unchecked(buf, *gas_used);

--- a/src/receipt/receipt_std.rs
+++ b/src/receipt/receipt_std.rs
@@ -4,6 +4,7 @@ use fuel_asm::InstructionResult;
 use fuel_types::bytes::{self, SizedBytes, WORD_SIZE};
 use fuel_types::Word;
 
+use crate::receipt::script_result::ScriptExecutionResult;
 use std::io::{self, Write};
 
 impl io::Read for Receipt {
@@ -169,7 +170,7 @@ impl io::Read for Receipt {
             Self::ScriptResult { result, gas_used } => {
                 let buf = bytes::store_number_unchecked(buf, ReceiptRepr::ScriptResult as Word);
 
-                let result = Word::from(*result);
+                let result: Word = (*result).into();
                 let buf = bytes::store_number_unchecked(buf, result);
 
                 bytes::store_number_unchecked(buf, *gas_used);
@@ -258,7 +259,7 @@ impl io::Write for Receipt {
 
                 let id = id.into();
 
-                *self = Self::panic(id, reason, pc, is);
+                *self = Self::panic(id, InstructionResult::from(reason), pc, is);
             }
 
             ReceiptRepr::Revert => {
@@ -344,9 +345,9 @@ impl io::Write for Receipt {
                 let (result, buf) = unsafe { bytes::restore_word_unchecked(buf) };
                 let (gas_used, _) = unsafe { bytes::restore_word_unchecked(buf) };
 
-                let result = InstructionResult::from(result);
+                let result = ScriptExecutionResult::from(result);
 
-                *self = Self::script_result(result, gas_used);
+                *self = Self::script_result(result.into(), gas_used);
             }
         }
 

--- a/src/receipt/script_result.rs
+++ b/src/receipt/script_result.rs
@@ -27,7 +27,7 @@ impl From<u64> for ScriptExecutionResult {
         match value {
             0x00 => Self::Success,
             0x01 => Self::Revert,
-            0x02 => Self::Revert,
+            0x02 => Self::Panic,
             value => Self::GenericFailure(value),
         }
     }

--- a/src/receipt/script_result.rs
+++ b/src/receipt/script_result.rs
@@ -1,0 +1,34 @@
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[cfg_attr(
+    feature = "serde-types-minimal",
+    derive(serde::Serialize, serde::Deserialize)
+)]
+pub enum ScriptExecutionResult {
+    Success,
+    Revert,
+    Panic,
+    // Generic failure case since any u64 is valid here
+    GenericFailure(u64),
+}
+
+impl From<ScriptExecutionResult> for u64 {
+    fn from(result: ScriptExecutionResult) -> Self {
+        match result {
+            ScriptExecutionResult::Success => 0x00,
+            ScriptExecutionResult::Revert => 0x01,
+            ScriptExecutionResult::Panic => 0x02,
+            ScriptExecutionResult::GenericFailure(value) => value,
+        }
+    }
+}
+
+impl From<u64> for ScriptExecutionResult {
+    fn from(value: u64) -> Self {
+        match value {
+            0x00 => Self::Success,
+            0x01 => Self::Revert,
+            0x02 => Self::Revert,
+            value => Self::GenericFailure(value),
+        }
+    }
+}

--- a/src/receipt/script_result.rs
+++ b/src/receipt/script_result.rs
@@ -1,3 +1,5 @@
+use fuel_types::Word;
+
 #[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
 #[cfg_attr(
     feature = "serde-types-minimal",
@@ -11,7 +13,7 @@ pub enum ScriptExecutionResult {
     GenericFailure(u64),
 }
 
-impl From<ScriptExecutionResult> for u64 {
+impl From<ScriptExecutionResult> for Word {
     fn from(result: ScriptExecutionResult) -> Self {
         match result {
             ScriptExecutionResult::Success => 0x00,
@@ -22,7 +24,7 @@ impl From<ScriptExecutionResult> for u64 {
     }
 }
 
-impl From<u64> for ScriptExecutionResult {
+impl From<Word> for ScriptExecutionResult {
     fn from(value: u64) -> Self {
         match value {
             0x00 => Self::Success,

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -483,6 +483,10 @@ fn receipt() {
             rng.gen(),
             rng.gen(),
         ),
+        Receipt::script_result(ScriptExecutionResult::Success, rng.gen()),
+        Receipt::script_result(ScriptExecutionResult::Panic, rng.gen()),
+        Receipt::script_result(ScriptExecutionResult::Revert, rng.gen()),
+        Receipt::script_result(ScriptExecutionResult::GenericFailure(rng.gen()), rng.gen()),
     ]);
 }
 

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -207,215 +207,280 @@ fn receipt() {
             rng.gen(),
             rng.gen(),
         ),
-        Receipt::script_result(InstructionResult::success(), rng.gen()),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
+            InstructionResult::success(),
+            rng.gen(),
+            rng.gen(),
+        ),
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::Revert,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::OutOfGas,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::TransactionValidity,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::MemoryOverflow,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ArithmeticOverflow,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ContractNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::MemoryOwnership,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::NotEnoughBalance,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ExpectedInternalContext,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::AssetIdNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::InputNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::OutputNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::WitnessNotFound,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::TransactionMaturity,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::InvalidMetadataIdentifier,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::MalformedCallStructure,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ReservedRegisterNotWritable,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ErrorFlag,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::InvalidImmediateValue,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ExpectedCoinInput,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::MaxMemoryAccess,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::MemoryWriteOverlap,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ContractNotInInputs,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::InternalBalanceOverflow,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ContractMaxSize,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ExpectedUnallocatedStack,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::MaxStaticContractsReached,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::TransferAmountCannotBeZero,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ExpectedOutputVariable,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
             rng.gen(),
+            rng.gen(),
         ),
-        Receipt::script_result(
+        Receipt::panic(
+            rng.gen(),
             InstructionResult::error(
                 PanicReason::ExpectedParentInternalContext,
                 Opcode::JI(rng.gen::<Immediate24>() & 0xffffff).into(),
             ),
+            rng.gen(),
             rng.gen(),
         ),
     ]);


### PR DESCRIPTION
This PR makes necessary changes in order for the fuel_tx::Receipt type able to reflect the recent spec change of ScriptResult reporting Reverts as a transaction failure.

Replaced usage of InstructionResult for ScriptResult `result` field because:
- InstructionResult includes a panic reason, and it's counter-intuitive to use a type called PanicReason for representing a success. This led to obscure logs for users where they'd see a `PanicReason::RESERV00` which could either mean success or revert.
- While there is a PanicReason::Revert, this would also be misleading since a revert can never cause a panic (unless it was out of gas, but then the panic reason should be OutOfGas, not revert).
- InstructionResult is also incompatible with fully representing a revert. This is because `rA` for a revert requires a full word, so it's not possible to pack both variants of InstructionResult (from panic) and `rA` (from revert) into a single word field for result.

ScriptResult.result() now falls in line closer with the specs:
  - 0 == Success
  - 1 == Revert
  - 2 == Panic
  - anything else == Generic Error

This is the most transparency ScriptResult is able to provide using only a single u64 without potential loss of data. A new ScriptExecutionResult type is used to alias these result values to increase transparency for downstream Rust consumers.

The Panic receipt was also modified to use `InstructionResult` instead of `Word` for its' `reason` field. The VM was already encoding an InstructionResult into Panic receipts, but because the reason field used a `Word`, the InstructionResult and panic reason was opaque. As an example, when debugging panic receipts a user would see something like `Panic { reason: 18446744073709, .. }`, which was not helpful and didn't leverage existing available types like InstructionResult or PanicReason. This resolves any confusion that may arise from how to parse the reason field on a Panic, since the reason is no longer specified (https://github.com/FuelLabs/fuel-specs/pull/256) and a Word provided no guarantees whether the VM is using an `InstructionResult`, `PanicReason`, or some other kind of arbitrary value.

fixes: #88 