### PR TITLE
Make offsets public

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,3 +1,6 @@
+use fuel_types::bytes::WORD_SIZE;
+use fuel_types::{Bytes32, Salt};
+
 /// Maximum contract size, in bytes.
 pub const CONTRACT_MAX_SIZE: u64 = 16 * 1024 * 1024;
 
@@ -34,3 +37,29 @@ pub const MAX_PREDICATE_LENGTH: u64 = 1024 * 1024;
 // TODO set max predicate data length value
 /// Maximum length of predicate data, in bytes.
 pub const MAX_PREDICATE_DATA_LENGTH: u64 = 1024 * 1024;
+
+pub const TRANSACTION_SCRIPT_FIXED_SIZE: usize = WORD_SIZE // Identifier
+    + WORD_SIZE // Gas price
+    + WORD_SIZE // Gas limit
+    + WORD_SIZE // Byte price
+    + WORD_SIZE // Maturity
+    + WORD_SIZE // Script size
+    + WORD_SIZE // Script data size
+    + WORD_SIZE // Inputs size
+    + WORD_SIZE // Outputs size
+    + WORD_SIZE // Witnesses size
+    + Bytes32::LEN; // Receipts root
+
+pub const TRANSACTION_CREATE_FIXED_SIZE: usize = WORD_SIZE // Identifier
+    + WORD_SIZE // Gas price
+    + WORD_SIZE // Gas limit
+    + WORD_SIZE // Byte price
+    + WORD_SIZE // Maturity
+    + WORD_SIZE // Bytecode size
+    + WORD_SIZE // Bytecode witness index
+    + WORD_SIZE // Static contracts size
+    + WORD_SIZE // Storage slots size
+    + WORD_SIZE // Inputs size
+    + WORD_SIZE // Outputs size
+    + WORD_SIZE // Witnesses size
+    + Salt::LEN; // Salt

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,7 +1,6 @@
 use crate::consts::*;
 
 use fuel_asm::Opcode;
-use fuel_types::bytes::WORD_SIZE;
 use fuel_types::{AssetId, Bytes32, ContractId, Salt, Word};
 
 #[cfg(feature = "std")]
@@ -30,32 +29,6 @@ pub use metadata::Metadata;
 pub use repr::TransactionRepr;
 pub use types::{Input, Output, StorageSlot, UtxoId, Witness};
 pub use validation::ValidationError;
-
-const TRANSACTION_SCRIPT_FIXED_SIZE: usize = WORD_SIZE // Identifier
-    + WORD_SIZE // Gas price
-    + WORD_SIZE // Gas limit
-    + WORD_SIZE // Byte price
-    + WORD_SIZE // Maturity
-    + WORD_SIZE // Script size
-    + WORD_SIZE // Script data size
-    + WORD_SIZE // Inputs size
-    + WORD_SIZE // Outputs size
-    + WORD_SIZE // Witnesses size
-    + Bytes32::LEN; // Receipts root
-
-const TRANSACTION_CREATE_FIXED_SIZE: usize = WORD_SIZE // Identifier
-    + WORD_SIZE // Gas price
-    + WORD_SIZE // Gas limit
-    + WORD_SIZE // Byte price
-    + WORD_SIZE // Maturity
-    + WORD_SIZE // Bytecode size
-    + WORD_SIZE // Bytecode witness index
-    + WORD_SIZE // Static contracts size
-    + WORD_SIZE // Storage slots size
-    + WORD_SIZE // Inputs size
-    + WORD_SIZE // Outputs size
-    + WORD_SIZE // Witnesses size
-    + Salt::LEN; // Salt
 
 /// Identification of transaction (also called transaction hash)
 pub type TxId = Bytes32;


### PR DESCRIPTION
Closes #98 

Was reading through fuel-tx as I try to get better understanding of all of fuels packages and crates and figured this may still be worth patching?

I moved them to `consts.rs` to sit with the other public constants, and then adjusted the rest of the package as necessary, but can move them back if needed.

I did also test that they exported correctly locally