### PR TITLE
Split `Input::coin` into predicate and signed

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,10 +1,9 @@
-use crate::{Input, Output, StorageSlot, Transaction, UtxoId, Witness};
+use crate::{Input, Output, StorageSlot, Transaction, Witness};
 
 use fuel_crypto::SecretKey;
-use fuel_types::{AssetId, ContractId, Salt, Word};
+use fuel_types::{ContractId, Salt, Word};
 
 use alloc::vec::Vec;
-use core::mem;
 
 #[derive(Debug, Clone)]
 pub struct TransactionBuilder<'a> {
@@ -57,6 +56,10 @@ impl<'a> TransactionBuilder<'a> {
         Self { tx, sign_keys }
     }
 
+    pub fn sign_keys(&self) -> &[&SecretKey] {
+        self.sign_keys.as_slice()
+    }
+
     pub fn gas_price(&mut self, gas_price: Word) -> &mut Self {
         self.tx.set_gas_price(gas_price);
 
@@ -81,28 +84,20 @@ impl<'a> TransactionBuilder<'a> {
         self
     }
 
+    #[cfg(feature = "std")]
     pub fn add_unsigned_coin_input(
         &mut self,
-        utxo_id: UtxoId,
+        utxo_id: crate::UtxoId,
         secret: &'a SecretKey,
         amount: Word,
-        asset_id: AssetId,
+        asset_id: fuel_types::AssetId,
         maturity: Word,
-        predicate: Vec<u8>,
-        predicate_data: Vec<u8>,
     ) -> &mut Self {
         let pk = secret.public_key();
 
         self.sign_keys.push(secret);
-        self.tx.add_unsigned_coin_input(
-            utxo_id,
-            &pk,
-            amount,
-            asset_id,
-            maturity,
-            predicate,
-            predicate_data,
-        );
+        self.tx
+            .add_unsigned_coin_input(utxo_id, &pk, amount, asset_id, maturity);
 
         self
     }
@@ -137,8 +132,9 @@ impl<'a> TransactionBuilder<'a> {
         self
     }
 
+    #[cfg(feature = "std")]
     pub fn finalize(&mut self) -> Transaction {
-        let mut tx = mem::take(&mut self.tx);
+        let mut tx = core::mem::take(&mut self.tx);
 
         self.sign_keys.iter().for_each(|k| tx.sign_inputs(k));
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -152,7 +152,7 @@ impl Transaction {
 
     pub fn input_asset_ids(&self) -> impl Iterator<Item = &AssetId> {
         self.inputs().iter().filter_map(|input| match input {
-            Input::Coin { asset_id, .. } => Some(asset_id),
+            Input::CoinSigned { asset_id, .. } => Some(asset_id),
             _ => None,
         })
     }
@@ -310,22 +310,11 @@ impl Transaction {
         amount: Word,
         asset_id: AssetId,
         maturity: Word,
-        predicate: Vec<u8>,
-        predicate_data: Vec<u8>,
     ) {
         let owner = Input::coin_owner(owner);
 
         let witness_index = self.witnesses().len() as u8;
-        let input = Input::coin(
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            witness_index,
-            maturity,
-            predicate,
-            predicate_data,
-        );
+        let input = Input::coin_signed(utxo_id, owner, amount, asset_id, witness_index, maturity);
 
         self._add_witness(Witness::default());
         self._add_input(input);
@@ -358,7 +347,7 @@ impl Transaction {
         inputs
             .iter()
             .filter_map(|input| match input {
-                Input::Coin {
+                Input::CoinSigned {
                     owner,
                     witness_index,
                     ..

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -152,7 +152,9 @@ impl Transaction {
 
     pub fn input_asset_ids(&self) -> impl Iterator<Item = &AssetId> {
         self.inputs().iter().filter_map(|input| match input {
-            Input::CoinSigned { asset_id, .. } => Some(asset_id),
+            Input::CoinPredicate { asset_id, .. } | Input::CoinSigned { asset_id, .. } => {
+                Some(asset_id)
+            }
             _ => None,
         })
     }

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -107,7 +107,7 @@ mod tests {
     use crate::consts::MAX_GAS_PER_TX;
     use crate::*;
 
-    use fuel_tx_test_helpers::generate_bytes;
+    use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
     use rand::rngs::StdRng;
     use rand::{Rng, RngCore, SeedableRng};
     use std::io::{Read, Write};
@@ -213,14 +213,26 @@ mod tests {
         assert_id_ne(tx, |t| t.set_maturity(t.maturity().not()));
 
         if !tx.inputs().is_empty() {
-            assert_io_ne!(tx, inputs_mut, Input::Coin, utxo_id, invert_utxo_id);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, owner, invert);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, amount, not);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, asset_id, invert);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, witness_index, not);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, maturity, not);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, predicate, inv_v);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, predicate_data, inv_v);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, utxo_id, invert_utxo_id);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, owner, invert);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, amount, not);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, asset_id, invert);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, witness_index, not);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, maturity, not);
+
+            assert_io_ne!(
+                tx,
+                inputs_mut,
+                Input::CoinPredicate,
+                utxo_id,
+                invert_utxo_id
+            );
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, owner, invert);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, amount, not);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, asset_id, invert);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, maturity, not);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, predicate, inv_v);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, predicate_data, inv_v);
 
             assert_io_eq!(tx, inputs_mut, Input::Contract, utxo_id, invert_utxo_id);
             assert_io_eq!(tx, inputs_mut, Input::Contract, balance_root, invert);
@@ -272,14 +284,21 @@ mod tests {
         let inputs = vec![
             vec![],
             vec![
-                Input::coin(
+                Input::coin_signed(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                    generate_bytes(rng),
+                ),
+                Input::coin_predicate(
+                    rng.gen(),
+                    rng.gen(),
+                    rng.next_u64(),
+                    rng.gen(),
+                    rng.next_u64(),
+                    generate_nonempty_bytes(rng),
                     generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),

--- a/src/transaction/offset.rs
+++ b/src/transaction/offset.rs
@@ -41,7 +41,7 @@ impl Transaction {
     pub(crate) fn _input_coin_predicate_offset(&self, index: usize) -> Option<usize> {
         self.input_offset(index)
             .map(|ofs| ofs + Input::coin_predicate_offset())
-            .filter(|_| self.inputs()[index].is_coin())
+            .filter(|_| self.inputs()[index].is_coin_predicate())
     }
 
     /// Return the serialized bytes offset of the input with the provided index

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -61,12 +61,20 @@ impl TryFrom<Word> for InputRepr {
     derive(serde::Serialize, serde::Deserialize)
 )]
 pub enum Input {
-    Coin {
+    CoinSigned {
         utxo_id: UtxoId,
         owner: Address,
         amount: Word,
         asset_id: AssetId,
         witness_index: u8,
+        maturity: Word,
+    },
+
+    CoinPredicate {
+        utxo_id: UtxoId,
+        owner: Address,
+        amount: Word,
+        asset_id: AssetId,
         maturity: Word,
         predicate: Vec<u8>,
         predicate_data: Vec<u8>,
@@ -94,7 +102,9 @@ impl Default for Input {
 impl bytes::SizedBytes for Input {
     fn serialized_size(&self) -> usize {
         match self {
-            Self::Coin {
+            Self::CoinSigned { .. } => INPUT_COIN_FIXED_SIZE,
+
+            Self::CoinPredicate {
                 predicate,
                 predicate_data,
                 ..
@@ -104,7 +114,7 @@ impl bytes::SizedBytes for Input {
                     + bytes::padded_len(predicate_data.as_slice())
             }
 
-            _ => INPUT_CONTRACT_SIZE,
+            Self::Contract { .. } => INPUT_CONTRACT_SIZE,
         }
     }
 }
@@ -117,25 +127,41 @@ impl Input {
         owner.into()
     }
 
-    pub const fn coin(
+    pub const fn coin_predicate(
+        utxo_id: UtxoId,
+        owner: Address,
+        amount: Word,
+        asset_id: AssetId,
+        maturity: Word,
+        predicate: Vec<u8>,
+        predicate_data: Vec<u8>,
+    ) -> Self {
+        Self::CoinPredicate {
+            utxo_id,
+            owner,
+            amount,
+            asset_id,
+            maturity,
+            predicate,
+            predicate_data,
+        }
+    }
+
+    pub const fn coin_signed(
         utxo_id: UtxoId,
         owner: Address,
         amount: Word,
         asset_id: AssetId,
         witness_index: u8,
         maturity: Word,
-        predicate: Vec<u8>,
-        predicate_data: Vec<u8>,
     ) -> Self {
-        Self::Coin {
+        Self::CoinSigned {
             utxo_id,
             owner,
             amount,
             asset_id,
             witness_index,
             maturity,
-            predicate,
-            predicate_data,
         }
     }
 
@@ -155,7 +181,8 @@ impl Input {
 
     pub const fn utxo_id(&self) -> &UtxoId {
         match self {
-            Self::Coin { utxo_id, .. } => utxo_id,
+            Self::CoinSigned { utxo_id, .. } => utxo_id,
+            Self::CoinPredicate { utxo_id, .. } => utxo_id,
             Self::Contract { utxo_id, .. } => utxo_id,
         }
     }
@@ -164,7 +191,7 @@ impl Input {
     /// type `Coin`
     pub fn predicate(&self) -> Option<(&[u8], &[u8])> {
         match self {
-            Input::Coin {
+            Input::CoinPredicate {
                 predicate,
                 predicate_data,
                 ..
@@ -174,8 +201,12 @@ impl Input {
         }
     }
 
-    pub const fn is_coin(&self) -> bool {
-        matches!(self, Input::Coin { .. })
+    pub const fn is_coin_signed(&self) -> bool {
+        matches!(self, Input::CoinSigned { .. })
+    }
+
+    pub const fn is_coin_predicate(&self) -> bool {
+        matches!(self, Input::CoinPredicate { .. })
     }
 
     pub const fn coin_predicate_offset() -> usize {
@@ -184,7 +215,7 @@ impl Input {
 
     pub fn coin_predicate_data_offset(&self) -> Option<usize> {
         match self {
-            Input::Coin { predicate, .. } => {
+            Input::CoinPredicate { predicate, .. } => {
                 Some(Self::coin_predicate_offset() + bytes::padded_len(predicate.as_slice()))
             }
 
@@ -202,12 +233,35 @@ impl io::Read for Input {
         }
 
         match self {
-            Self::Coin {
+            Self::CoinSigned {
                 utxo_id,
                 owner,
                 amount,
                 asset_id,
                 witness_index,
+                maturity,
+            } => {
+                let buf = bytes::store_number_unchecked(buf, InputRepr::Coin as Word);
+                let buf = bytes::store_array_unchecked(buf, utxo_id.tx_id());
+                let buf = bytes::store_number_unchecked(buf, utxo_id.output_index() as Word);
+                let buf = bytes::store_array_unchecked(buf, owner);
+                let buf = bytes::store_number_unchecked(buf, *amount);
+                let buf = bytes::store_array_unchecked(buf, asset_id);
+                let buf = bytes::store_number_unchecked(buf, *witness_index);
+                let buf = bytes::store_number_unchecked(buf, *maturity);
+
+                // Predicate len zeroed for signed coin
+                let buf = bytes::store_number_unchecked(buf, 0u64);
+
+                // Predicate data len zeroed for signed coin
+                bytes::store_number_unchecked(buf, 0u64);
+            }
+
+            Self::CoinPredicate {
+                utxo_id,
+                owner,
+                amount,
+                asset_id,
                 maturity,
                 predicate,
                 predicate_data,
@@ -218,7 +272,9 @@ impl io::Read for Input {
                 let buf = bytes::store_array_unchecked(buf, owner);
                 let buf = bytes::store_number_unchecked(buf, *amount);
                 let buf = bytes::store_array_unchecked(buf, asset_id);
-                let buf = bytes::store_number_unchecked(buf, *witness_index);
+
+                // Witness index zeroed for coin predicate
+                let buf = bytes::store_number_unchecked(buf, 0u64);
                 let buf = bytes::store_number_unchecked(buf, *maturity);
 
                 let buf = bytes::store_number_unchecked(buf, predicate.len() as Word);
@@ -286,15 +342,25 @@ impl io::Write for Input {
                 let owner = owner.into();
                 let asset_id = asset_id.into();
 
-                *self = Self::Coin {
-                    utxo_id,
-                    owner,
-                    amount,
-                    asset_id,
-                    witness_index,
-                    maturity,
-                    predicate,
-                    predicate_data,
+                *self = if predicate.is_empty() {
+                    Self::CoinSigned {
+                        utxo_id,
+                        owner,
+                        amount,
+                        asset_id,
+                        witness_index,
+                        maturity,
+                    }
+                } else {
+                    Self::CoinPredicate {
+                        utxo_id,
+                        owner,
+                        amount,
+                        asset_id,
+                        maturity,
+                        predicate,
+                        predicate_data,
+                    }
                 };
 
                 Ok(n)

--- a/src/transaction/types/witness.rs
+++ b/src/transaction/types/witness.rs
@@ -69,7 +69,7 @@ impl Distribution<Witness> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Witness {
         let len = rng.gen_range(0..512);
 
-        let mut data = vec![0u8; len];
+        let mut data = alloc::vec![0u8; len];
         rng.fill_bytes(data.as_mut_slice());
 
         data.into()

--- a/src/transaction/validation/error.rs
+++ b/src/transaction/validation/error.rs
@@ -17,6 +17,9 @@ pub enum ValidationError {
     InputCoinPredicateDataLength {
         index: usize,
     },
+    InputCoinPredicateOwner {
+        index: usize,
+    },
     InputCoinWitnessIndexBounds {
         index: usize,
     },

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -10,3 +10,7 @@ fuel-crypto = { version = "0.4", default-features = false, features = ["random"]
 fuel-tx = { path = "../../fuel-tx", default-features = false, features = ["alloc","builder","internals","random"] }
 fuel-types = { version = "0.3", default-features = false, features = ["random"] }
 rand = { version = "0.8", default-features = false }
+
+[features]
+default = ["std"]
+std = ["fuel-tx/default", "fuel-types/default"]

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -1,15 +1,25 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 
-use fuel_crypto::SecretKey;
-use fuel_tx::{Input, Output, Transaction, TransactionBuilder};
-use fuel_types::bytes::Deserializable;
-use rand::distributions::{Distribution, Uniform};
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
+
+#[cfg(feature = "std")]
+pub use use_std::*;
 
 use alloc::vec::Vec;
+
+pub fn generate_nonempty_bytes<R>(rng: &mut R) -> Vec<u8>
+where
+    R: Rng,
+{
+    let len = rng.gen_range(1..512);
+
+    let mut data = alloc::vec![0u8; len];
+    rng.fill_bytes(data.as_mut_slice());
+
+    data.into()
+}
 
 pub fn generate_bytes<R>(rng: &mut R) -> Vec<u8>
 where
@@ -23,178 +33,203 @@ where
     data.into()
 }
 
-pub struct TransactionFactory<R>
-where
-    R: Rng,
-{
-    rng: R,
-    input_sampler: Uniform<usize>,
-    output_sampler: Uniform<usize>,
-    tx_sampler: Uniform<usize>,
-}
+#[cfg(feature = "std")]
+mod use_std {
+    use fuel_crypto::SecretKey;
+    use fuel_tx::{Input, Output, Transaction, TransactionBuilder};
+    use fuel_types::bytes::Deserializable;
+    use rand::distributions::{Distribution, Uniform};
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
-impl<R> From<R> for TransactionFactory<R>
-where
-    R: Rng,
-{
-    fn from(rng: R) -> Self {
-        let tx_sampler = Uniform::from(0..2);
-        let input_sampler = Uniform::from(0..2);
-        let output_sampler = Uniform::from(0..6);
+    use crate::{generate_bytes, generate_nonempty_bytes};
 
-        // Trick to enforce coverage of all variants in compile-time
-        //
-        // When and if a new variant is added, this implementation enforces it will be
-        // listed here.
-        debug_assert!({
-            Input::from_bytes(&[])
-                .map(|i| match i {
-                    Input::Coin { .. } => (),
-                    Input::Contract { .. } => (),
-                })
-                .unwrap_or(());
-
-            Output::from_bytes(&[])
-                .map(|o| match o {
-                    Output::Coin { .. } => (),
-                    Output::Contract { .. } => (),
-                    Output::Withdrawal { .. } => (),
-                    Output::Change { .. } => (),
-                    Output::Variable { .. } => (),
-                    Output::ContractCreated { .. } => (),
-                })
-                .unwrap_or(());
-
-            Transaction::from_bytes(&[])
-                .map(|t| match t {
-                    Transaction::Script { .. } => (),
-                    Transaction::Create { .. } => (),
-                })
-                .unwrap_or(());
-
-            true
-        });
-
-        Self {
-            rng,
-            tx_sampler,
-            input_sampler,
-            output_sampler,
-        }
-    }
-}
-
-impl TransactionFactory<StdRng> {
-    pub fn from_seed(seed: u64) -> Self {
-        StdRng::seed_from_u64(seed).into()
-    }
-}
-
-impl<R> TransactionFactory<R>
-where
-    R: Rng,
-{
-    pub fn transaction(&mut self) -> Transaction {
-        self.transaction_with_keys().0
+    pub struct TransactionFactory<R>
+    where
+        R: Rng,
+    {
+        rng: R,
+        input_sampler: Uniform<usize>,
+        output_sampler: Uniform<usize>,
+        tx_sampler: Uniform<usize>,
     }
 
-    pub fn transaction_with_keys(&mut self) -> (Transaction, Vec<SecretKey>) {
-        let variant = self.tx_sampler.sample(&mut self.rng);
+    impl<R> From<R> for TransactionFactory<R>
+    where
+        R: Rng,
+    {
+        fn from(rng: R) -> Self {
+            let tx_sampler = Uniform::from(0..2);
+            let input_sampler = Uniform::from(0..3);
+            let output_sampler = Uniform::from(0..6);
 
-        let contracts = self.rng.gen_range(0..10);
-        let slots = self.rng.gen_range(0..10);
-        let mut builder = match variant {
-            0 => TransactionBuilder::script(
-                generate_bytes(&mut self.rng),
-                generate_bytes(&mut self.rng),
-            ),
-            1 => TransactionBuilder::create(
-                self.rng.gen(),
-                self.rng.gen(),
-                (0..contracts).map(|_| self.rng.gen()).collect(),
-                (0..slots).map(|_| self.rng.gen()).collect(),
-            ),
-            _ => unreachable!(),
-        };
+            // Trick to enforce coverage of all variants in compile-time
+            //
+            // When and if a new variant is added, this implementation enforces it will be
+            // listed here.
+            debug_assert!({
+                Input::from_bytes(&[])
+                    .map(|i| match i {
+                        Input::CoinSigned { .. } => (),
+                        Input::CoinPredicate { .. } => (),
+                        Input::Contract { .. } => (),
+                    })
+                    .unwrap_or(());
 
-        let inputs = self.rng.gen_range(0..10);
-        let mut input_keys = Vec::with_capacity(10);
+                Output::from_bytes(&[])
+                    .map(|o| match o {
+                        Output::Coin { .. } => (),
+                        Output::Contract { .. } => (),
+                        Output::Withdrawal { .. } => (),
+                        Output::Change { .. } => (),
+                        Output::Variable { .. } => (),
+                        Output::ContractCreated { .. } => (),
+                    })
+                    .unwrap_or(());
 
-        for _ in 0..inputs {
-            let variant = self.input_sampler.sample(&mut self.rng);
+                Transaction::from_bytes(&[])
+                    .map(|t| match t {
+                        Transaction::Script { .. } => (),
+                        Transaction::Create { .. } => (),
+                    })
+                    .unwrap_or(());
 
-            match variant {
-                0 => {
-                    let secret = SecretKey::random(&mut self.rng);
+                true
+            });
 
-                    input_keys.push(secret);
-                }
-
-                1 => {
-                    let input = Input::contract(
-                        self.rng.gen(),
-                        self.rng.gen(),
-                        self.rng.gen(),
-                        self.rng.gen(),
-                    );
-
-                    builder.add_input(input);
-                }
-
-                _ => unreachable!(),
+            Self {
+                rng,
+                tx_sampler,
+                input_sampler,
+                output_sampler,
             }
         }
+    }
 
-        for i in 0..input_keys.len() {
-            builder.add_unsigned_coin_input(
-                self.rng.gen(),
-                &input_keys[i],
-                self.rng.gen(),
-                self.rng.gen(),
-                self.rng.gen(),
-                generate_bytes(&mut self.rng),
-                generate_bytes(&mut self.rng),
-            );
+    impl TransactionFactory<StdRng> {
+        pub fn from_seed(seed: u64) -> Self {
+            StdRng::seed_from_u64(seed).into()
+        }
+    }
+
+    impl<R> TransactionFactory<R>
+    where
+        R: Rng,
+    {
+        pub fn transaction(&mut self) -> Transaction {
+            self.transaction_with_keys().0
         }
 
-        let outputs = self.rng.gen_range(0..10);
-        for _ in 0..outputs {
-            let variant = self.output_sampler.sample(&mut self.rng);
+        pub fn transaction_with_keys(&mut self) -> (Transaction, Vec<SecretKey>) {
+            let variant = self.tx_sampler.sample(&mut self.rng);
 
-            let output = match variant {
-                0 => Output::coin(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                1 => Output::contract(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                2 => Output::withdrawal(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                3 => Output::change(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                4 => Output::variable(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                5 => Output::contract_created(self.rng.gen(), self.rng.gen()),
-
+            let contracts = self.rng.gen_range(0..10);
+            let slots = self.rng.gen_range(0..10);
+            let mut builder = match variant {
+                0 => TransactionBuilder::script(
+                    generate_bytes(&mut self.rng),
+                    generate_bytes(&mut self.rng),
+                ),
+                1 => TransactionBuilder::create(
+                    self.rng.gen(),
+                    self.rng.gen(),
+                    (0..contracts).map(|_| self.rng.gen()).collect(),
+                    (0..slots).map(|_| self.rng.gen()).collect(),
+                ),
                 _ => unreachable!(),
             };
 
-            builder.add_output(output);
+            let inputs = self.rng.gen_range(0..10);
+            let mut input_keys = Vec::with_capacity(10);
+
+            for _ in 0..inputs {
+                let variant = self.input_sampler.sample(&mut self.rng);
+
+                match variant {
+                    0 => {
+                        let secret = SecretKey::random(&mut self.rng);
+
+                        input_keys.push(secret);
+                    }
+
+                    1 => {
+                        let input = Input::coin_predicate(
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            generate_nonempty_bytes(&mut self.rng),
+                            generate_bytes(&mut self.rng),
+                        );
+
+                        builder.add_input(input);
+                    }
+
+                    2 => {
+                        let input = Input::contract(
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                        );
+
+                        builder.add_input(input);
+                    }
+
+                    _ => unreachable!(),
+                }
+            }
+
+            for i in 0..input_keys.len() {
+                builder.add_unsigned_coin_input(
+                    self.rng.gen(),
+                    &input_keys[i],
+                    self.rng.gen(),
+                    self.rng.gen(),
+                    self.rng.gen(),
+                );
+            }
+
+            let outputs = self.rng.gen_range(0..10);
+            for _ in 0..outputs {
+                let variant = self.output_sampler.sample(&mut self.rng);
+
+                let output = match variant {
+                    0 => Output::coin(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    1 => Output::contract(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    2 => Output::withdrawal(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    3 => Output::change(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    4 => Output::variable(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    5 => Output::contract_created(self.rng.gen(), self.rng.gen()),
+
+                    _ => unreachable!(),
+                };
+
+                builder.add_output(output);
+            }
+
+            let witnesses = self.rng.gen_range(0..10);
+            for _ in 0..witnesses {
+                let witness = generate_bytes(&mut self.rng).into();
+
+                builder.add_witness(witness);
+            }
+
+            let tx = builder.finalize();
+
+            (tx, input_keys)
         }
-
-        let witnesses = self.rng.gen_range(0..10);
-        for _ in 0..witnesses {
-            let witness = generate_bytes(&mut self.rng).into();
-
-            builder.add_witness(witness);
-        }
-
-        let tx = builder.finalize();
-
-        (tx, input_keys)
     }
-}
 
-impl<R> Iterator for TransactionFactory<R>
-where
-    R: Rng,
-{
-    type Item = (Transaction, Vec<SecretKey>);
+    impl<R> Iterator for TransactionFactory<R>
+    where
+        R: Rng,
+    {
+        type Item = (Transaction, Vec<SecretKey>);
 
-    fn next(&mut self) -> Option<(Transaction, Vec<SecretKey>)> {
-        Some(self.transaction_with_keys())
+        fn next(&mut self) -> Option<(Transaction, Vec<SecretKey>)> {
+            Some(self.transaction_with_keys())
+        }
     }
 }

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,7 +1,8 @@
 use fuel_asm::Opcode;
+use fuel_crypto::Hasher;
 use fuel_tx::consts::MAX_GAS_PER_TX;
 use fuel_tx::*;
-use fuel_tx_test_helpers::generate_bytes;
+use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
 use fuel_types::{bytes, ContractId, Immediate24};
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
@@ -81,49 +82,25 @@ fn witness() {
 
 #[test]
 fn input() {
-    let mut rng_base = StdRng::seed_from_u64(8586);
-    let rng = &mut rng_base;
+    let rng = &mut StdRng::seed_from_u64(8586);
 
     assert_encoding_correct(&[
-        Input::coin(
+        Input::coin_signed(
             rng.gen(),
             rng.gen(),
             rng.next_u64(),
             rng.gen(),
             rng.gen(),
             rng.next_u64(),
-            generate_bytes(rng),
-            generate_bytes(rng),
         ),
-        Input::coin(
+        Input::coin_predicate(
             rng.gen(),
             rng.gen(),
             rng.next_u64(),
             rng.gen(),
             rng.gen(),
-            rng.next_u64(),
-            vec![],
+            generate_nonempty_bytes(rng),
             generate_bytes(rng),
-        ),
-        Input::coin(
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            generate_bytes(rng),
-            vec![],
-        ),
-        Input::coin(
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            vec![],
-            vec![],
         ),
         Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
     ]);
@@ -694,15 +671,17 @@ fn create_input_coin_data_offset() {
         vec![generate_bytes(rng).into(), generate_bytes(rng).into()],
     ];
 
-    let predicate = generate_bytes(rng);
+    let predicate = generate_nonempty_bytes(rng);
     let predicate_data = generate_bytes(rng);
-    let input_coin = Input::coin(
+
+    let owner = (*Hasher::hash(predicate.as_slice())).into();
+
+    let input_coin = Input::coin_predicate(
         rng.gen(),
-        rng.gen(),
+        owner,
         rng.next_u64(),
         rng.gen(),
         rng.gen(),
-        rng.next_u64(),
         predicate.clone(),
         predicate_data,
     );
@@ -794,15 +773,17 @@ fn script_input_coin_data_offset() {
         vec![generate_bytes(rng).into(), generate_bytes(rng).into()],
     ];
 
-    let predicate = generate_bytes(rng);
+    let predicate = generate_nonempty_bytes(rng);
     let predicate_data = generate_bytes(rng);
-    let input_coin = Input::coin(
+
+    let owner = (*Hasher::hash(predicate.as_slice())).into();
+
+    let input_coin = Input::coin_predicate(
         rng.gen(),
-        rng.gen(),
+        owner,
         rng.next_u64(),
         rng.gen(),
         rng.gen(),
-        rng.next_u64(),
         predicate.clone(),
         predicate_data,
     );

--- a/tests/valid_cases/input.rs
+++ b/tests/valid_cases/input.rs
@@ -1,12 +1,11 @@
-use fuel_crypto::SecretKey;
-use fuel_tx::consts::*;
+use fuel_crypto::{Hasher, SecretKey};
 use fuel_tx::*;
-use fuel_tx_test_helpers::TransactionFactory;
+use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes, TransactionFactory};
 use rand::rngs::StdRng;
 use rand::{Rng, SeedableRng};
 
 #[test]
-fn coin() {
+fn coin_signed() {
     let rng = &mut StdRng::seed_from_u64(8586);
 
     let mut factory = TransactionFactory::from_seed(3493);
@@ -21,7 +20,7 @@ fn coin() {
             .iter()
             .enumerate()
             .try_for_each(|(index, input)| match input {
-                Input::Coin { .. } => input.validate(index, &txhash, outputs, witnesses),
+                Input::CoinSigned { .. } => input.validate(index, &txhash, outputs, witnesses),
                 _ => Ok(()),
             })
     }
@@ -34,8 +33,6 @@ fn coin() {
         amount: Word,
         asset_id: AssetId,
         maturity: Word,
-        predicate: Vec<u8>,
-        predicate_data: Vec<u8>,
     ) -> Result<(), ValidationError>
     where
         R: Rng,
@@ -46,15 +43,7 @@ fn coin() {
         let secret = SecretKey::random(rng);
         let public = secret.public_key();
 
-        tx.add_unsigned_coin_input(
-            utxo_id,
-            &public,
-            amount,
-            asset_id,
-            maturity,
-            predicate,
-            predicate_data,
-        );
+        tx.add_unsigned_coin_input(utxo_id, &public, amount, asset_id, maturity);
 
         tx.sign_inputs(&secret);
         keys.iter().for_each(|sk| tx.sign_inputs(sk));
@@ -71,90 +60,19 @@ fn coin() {
     let amount = rng.gen();
     let asset_id = rng.gen();
     let maturity = rng.gen();
-    sign_coin_and_validate(
-        rng,
-        txs.by_ref(),
-        utxo_id,
-        amount,
-        asset_id,
-        maturity,
-        vec![0u8; MAX_PREDICATE_LENGTH as usize],
-        vec![],
-    )
-    .expect("Failed to validate transaction");
+    sign_coin_and_validate(rng, txs.by_ref(), utxo_id, amount, asset_id, maturity)
+        .expect("Failed to validate transaction");
 
     let utxo_id = rng.gen();
     let amount = rng.gen();
     let asset_id = rng.gen();
     let maturity = rng.gen();
-    sign_coin_and_validate(
-        rng,
-        txs.by_ref(),
-        utxo_id,
-        amount,
-        asset_id,
-        maturity,
-        vec![],
-        vec![0u8; MAX_PREDICATE_DATA_LENGTH as usize],
-    )
-    .expect("Failed to validate transaction");
-
-    let utxo_id = rng.gen();
-    let amount = rng.gen();
-    let asset_id = rng.gen();
-    let maturity = rng.gen();
-    let err = sign_coin_and_validate(
-        rng,
-        txs.by_ref(),
-        utxo_id,
-        amount,
-        asset_id,
-        maturity,
-        vec![0u8; MAX_PREDICATE_LENGTH as usize + 1],
-        vec![],
-    )
-    .err()
-    .expect("Expected failure");
-
-    assert!(matches!(
-        err,
-        ValidationError::InputCoinPredicateLength { .. }
-    ));
-
-    let utxo_id = rng.gen();
-    let amount = rng.gen();
-    let asset_id = rng.gen();
-    let maturity = rng.gen();
-    let err = sign_coin_and_validate(
-        rng,
-        txs.by_ref(),
-        utxo_id,
-        amount,
-        asset_id,
-        maturity,
-        vec![],
-        vec![0u8; MAX_PREDICATE_DATA_LENGTH as usize + 1],
-    )
-    .err()
-    .expect("Expected failure");
-
-    assert!(matches!(
-        err,
-        ValidationError::InputCoinPredicateDataLength { .. }
-    ));
+    sign_coin_and_validate(rng, txs.by_ref(), utxo_id, amount, asset_id, maturity)
+        .expect("Failed to validate transaction");
 
     let mut tx = Transaction::default();
 
-    let input = Input::coin(
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        0,
-        rng.gen(),
-        vec![],
-        vec![],
-    );
+    let input = Input::coin_signed(rng.gen(), rng.gen(), rng.gen(), rng.gen(), 0, rng.gen());
     tx.add_input(input);
 
     let block_height = rng.gen();
@@ -164,6 +82,65 @@ fn coin() {
         err,
         ValidationError::InputCoinWitnessIndexBounds { .. }
     ));
+}
+
+#[test]
+fn coin_predicate() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
+    let txhash: Bytes32 = rng.gen();
+
+    let predicate = generate_nonempty_bytes(rng);
+    let owner = (*Hasher::hash(predicate.as_slice())).into();
+
+    Input::coin_predicate(
+        rng.gen(),
+        owner,
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+        predicate,
+        generate_bytes(rng),
+    )
+    .validate(1, &txhash, &[], &[])
+    .unwrap();
+
+    let predicate = vec![];
+    let owner = (*Hasher::hash(predicate.as_slice())).into();
+
+    let err = Input::coin_predicate(
+        rng.gen(),
+        owner,
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+        predicate,
+        generate_bytes(rng),
+    )
+    .validate(1, &txhash, &[], &[])
+    .err()
+    .unwrap();
+
+    assert_eq!(ValidationError::InputCoinPredicateLength { index: 1 }, err);
+
+    let mut predicate = generate_nonempty_bytes(rng);
+    let owner = (*Hasher::hash(predicate.as_slice())).into();
+    predicate[0] = predicate[0].wrapping_add(1);
+
+    let err = Input::coin_predicate(
+        rng.gen(),
+        owner,
+        rng.gen(),
+        rng.gen(),
+        rng.gen(),
+        predicate,
+        generate_bytes(rng),
+    )
+    .validate(1, &txhash, &[], &[])
+    .err()
+    .unwrap();
+
+    assert_eq!(ValidationError::InputCoinPredicateOwner { index: 1 }, err);
 }
 
 #[test]
@@ -223,16 +200,7 @@ fn contract() {
 fn transaction_with_duplicate_coin_inputs_is_invalid() {
     let rng = &mut StdRng::seed_from_u64(8586);
     let input_utxo_id: UtxoId = rng.gen();
-    let input = Input::coin(
-        input_utxo_id,
-        rng.gen(),
-        rng.gen(),
-        rng.gen(),
-        0,
-        0,
-        vec![],
-        vec![],
-    );
+    let input = Input::coin_signed(input_utxo_id, rng.gen(), rng.gen(), rng.gen(), 0, 0);
     let tx = TransactionBuilder::script(vec![], vec![])
         .add_input(input.clone())
         .add_input(input)

--- a/tests/valid_cases/output.rs
+++ b/tests/valid_cases/output.rs
@@ -1,5 +1,4 @@
 use fuel_tx::*;
-use fuel_tx_test_helpers::generate_bytes;
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
 
@@ -22,15 +21,13 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin(
+                Input::coin_signed(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                    generate_bytes(rng),
-                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],
@@ -41,15 +38,13 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin(
+                Input::coin_signed(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                    generate_bytes(rng),
-                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],
@@ -62,15 +57,13 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin(
+                Input::coin_signed(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                    generate_bytes(rng),
-                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -170,15 +170,7 @@ fn max_iow() {
         .gas_price(rng.gen())
         .gas_limit(MAX_GAS_PER_TX)
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            asset_id,
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, maturity);
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
         builder.add_output(Output::coin(rng.gen(), rng.gen(), asset_id));
@@ -207,15 +199,7 @@ fn max_iow() {
 
     let asset_id: AssetId = rng.gen();
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(
-            rng.gen(),
-            k,
-            rng.gen(),
-            asset_id,
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), asset_id, maturity);
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -244,15 +228,7 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(
-            rng.gen(),
-            k,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -284,15 +260,7 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(
-            rng.gen(),
-            k,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
     });
 
     while builder.outputs().len() < 1 + MAX_OUTPUTS as usize {
@@ -324,15 +292,7 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(
-            rng.gen(),
-            k,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -369,24 +329,8 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            a,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            b,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), b))
         .finalize()
@@ -397,24 +341,8 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            a,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            b,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .finalize()
@@ -431,24 +359,8 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            a,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            b,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), c))
         .finalize()
@@ -465,24 +377,8 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            a,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            b,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
         .add_output(Output::coin(rng.gen(), rng.next_u64(), a))
         .add_output(Output::coin(rng.gen(), rng.next_u64(), c))
         .finalize()
@@ -513,15 +409,7 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        asset_id,
-        rng.gen(),
-        generate_bytes(rng),
-        generate_bytes(rng),
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
     .finalize()
     .validate(block_height)
@@ -534,15 +422,7 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        asset_id,
-        rng.gen(),
-        generate_bytes(rng),
-        generate_bytes(rng),
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -561,15 +441,7 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        asset_id,
-        rng.gen(),
-        generate_bytes(rng),
-        generate_bytes(rng),
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -585,15 +457,7 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        asset_id,
-        rng.gen(),
-        generate_bytes(rng),
-        generate_bytes(rng),
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -617,15 +481,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), rng.gen(), maturity)
         .finalize()
         .validate(block_height)
         .expect("Failed to validate tx");
@@ -651,15 +507,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), rng.gen(), maturity)
         .add_output(Output::variable(rng.gen(), rng.gen(), rng.gen()))
         .finalize()
         .validate(block_height)
@@ -675,24 +523,8 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret_b,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), rng.gen(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
@@ -711,24 +543,8 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret_b,
-            rng.gen(),
-            asset_id,
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), asset_id, maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
         .finalize()
@@ -745,24 +561,8 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret_b,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), rng.gen(), maturity)
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .finalize()
@@ -779,15 +579,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_witness(vec![0xfa; CONTRACT_MAX_SIZE as usize / 4].into())
         .finalize()
@@ -798,15 +590,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_witness(vec![0xfa; 1 + CONTRACT_MAX_SIZE as usize].into())
         .finalize()
@@ -820,15 +604,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_witness(vec![0xfa; CONTRACT_MAX_SIZE as usize / 4].into())
         .finalize()
@@ -855,15 +631,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)
@@ -879,15 +647,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)
@@ -907,15 +667,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)
@@ -948,15 +700,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -972,15 +716,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)
@@ -998,15 +734,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)


### PR DESCRIPTION
The input coin defined in the specifications is an aggregated type
between two logical variants: signed and predicate.

When the input is expected to behave as coin, the signature validation
should seek its witness counterpart and check the signature with its
fields as arguments = except for predicate and its data.

When the input is expected to behave as predicate, the validation will
check if the owner is the hash of the predicate. The witness id is
entirely ignored.

It is canonical to Rust to split these two different logical structures
into different enum variants - even if we are to maintain the fuel specs
canonical serialization.

Closes #110