### PR TITLE
Revert "Split `Input::coin` into predicate and signed"

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,9 +1,10 @@
-use crate::{Input, Output, StorageSlot, Transaction, Witness};
+use crate::{Input, Output, StorageSlot, Transaction, UtxoId, Witness};
 
 use fuel_crypto::SecretKey;
-use fuel_types::{ContractId, Salt, Word};
+use fuel_types::{AssetId, ContractId, Salt, Word};
 
 use alloc::vec::Vec;
+use core::mem;
 
 #[derive(Debug, Clone)]
 pub struct TransactionBuilder<'a> {
@@ -56,10 +57,6 @@ impl<'a> TransactionBuilder<'a> {
         Self { tx, sign_keys }
     }
 
-    pub fn sign_keys(&self) -> &[&SecretKey] {
-        self.sign_keys.as_slice()
-    }
-
     pub fn gas_price(&mut self, gas_price: Word) -> &mut Self {
         self.tx.set_gas_price(gas_price);
 
@@ -84,20 +81,28 @@ impl<'a> TransactionBuilder<'a> {
         self
     }
 
-    #[cfg(feature = "std")]
     pub fn add_unsigned_coin_input(
         &mut self,
-        utxo_id: crate::UtxoId,
+        utxo_id: UtxoId,
         secret: &'a SecretKey,
         amount: Word,
-        asset_id: fuel_types::AssetId,
+        asset_id: AssetId,
         maturity: Word,
+        predicate: Vec<u8>,
+        predicate_data: Vec<u8>,
     ) -> &mut Self {
         let pk = secret.public_key();
 
         self.sign_keys.push(secret);
-        self.tx
-            .add_unsigned_coin_input(utxo_id, &pk, amount, asset_id, maturity);
+        self.tx.add_unsigned_coin_input(
+            utxo_id,
+            &pk,
+            amount,
+            asset_id,
+            maturity,
+            predicate,
+            predicate_data,
+        );
 
         self
     }
@@ -132,9 +137,8 @@ impl<'a> TransactionBuilder<'a> {
         self
     }
 
-    #[cfg(feature = "std")]
     pub fn finalize(&mut self) -> Transaction {
-        let mut tx = core::mem::take(&mut self.tx);
+        let mut tx = mem::take(&mut self.tx);
 
         self.sign_keys.iter().for_each(|k| tx.sign_inputs(k));
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -152,9 +152,7 @@ impl Transaction {
 
     pub fn input_asset_ids(&self) -> impl Iterator<Item = &AssetId> {
         self.inputs().iter().filter_map(|input| match input {
-            Input::CoinPredicate { asset_id, .. } | Input::CoinSigned { asset_id, .. } => {
-                Some(asset_id)
-            }
+            Input::Coin { asset_id, .. } => Some(asset_id),
             _ => None,
         })
     }
@@ -312,11 +310,22 @@ impl Transaction {
         amount: Word,
         asset_id: AssetId,
         maturity: Word,
+        predicate: Vec<u8>,
+        predicate_data: Vec<u8>,
     ) {
         let owner = Input::coin_owner(owner);
 
         let witness_index = self.witnesses().len() as u8;
-        let input = Input::coin_signed(utxo_id, owner, amount, asset_id, witness_index, maturity);
+        let input = Input::coin(
+            utxo_id,
+            owner,
+            amount,
+            asset_id,
+            witness_index,
+            maturity,
+            predicate,
+            predicate_data,
+        );
 
         self._add_witness(Witness::default());
         self._add_input(input);
@@ -349,7 +358,7 @@ impl Transaction {
         inputs
             .iter()
             .filter_map(|input| match input {
-                Input::CoinSigned {
+                Input::Coin {
                     owner,
                     witness_index,
                     ..

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -107,7 +107,7 @@ mod tests {
     use crate::consts::MAX_GAS_PER_TX;
     use crate::*;
 
-    use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
+    use fuel_tx_test_helpers::generate_bytes;
     use rand::rngs::StdRng;
     use rand::{Rng, RngCore, SeedableRng};
     use std::io::{Read, Write};
@@ -213,26 +213,14 @@ mod tests {
         assert_id_ne(tx, |t| t.set_maturity(t.maturity().not()));
 
         if !tx.inputs().is_empty() {
-            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, utxo_id, invert_utxo_id);
-            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, owner, invert);
-            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, amount, not);
-            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, asset_id, invert);
-            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, witness_index, not);
-            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, maturity, not);
-
-            assert_io_ne!(
-                tx,
-                inputs_mut,
-                Input::CoinPredicate,
-                utxo_id,
-                invert_utxo_id
-            );
-            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, owner, invert);
-            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, amount, not);
-            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, asset_id, invert);
-            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, maturity, not);
-            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, predicate, inv_v);
-            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, predicate_data, inv_v);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, utxo_id, invert_utxo_id);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, owner, invert);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, amount, not);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, asset_id, invert);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, witness_index, not);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, maturity, not);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, predicate, inv_v);
+            assert_io_ne!(tx, inputs_mut, Input::Coin, predicate_data, inv_v);
 
             assert_io_eq!(tx, inputs_mut, Input::Contract, utxo_id, invert_utxo_id);
             assert_io_eq!(tx, inputs_mut, Input::Contract, balance_root, invert);
@@ -284,21 +272,14 @@ mod tests {
         let inputs = vec![
             vec![],
             vec![
-                Input::coin_signed(
+                Input::coin(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                ),
-                Input::coin_predicate(
-                    rng.gen(),
-                    rng.gen(),
-                    rng.next_u64(),
-                    rng.gen(),
-                    rng.next_u64(),
-                    generate_nonempty_bytes(rng),
+                    generate_bytes(rng),
                     generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),

--- a/src/transaction/offset.rs
+++ b/src/transaction/offset.rs
@@ -41,7 +41,7 @@ impl Transaction {
     pub(crate) fn _input_coin_predicate_offset(&self, index: usize) -> Option<usize> {
         self.input_offset(index)
             .map(|ofs| ofs + Input::coin_predicate_offset())
-            .filter(|_| self.inputs()[index].is_coin_predicate())
+            .filter(|_| self.inputs()[index].is_coin())
     }
 
     /// Return the serialized bytes offset of the input with the provided index

--- a/src/transaction/types/witness.rs
+++ b/src/transaction/types/witness.rs
@@ -69,7 +69,7 @@ impl Distribution<Witness> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Witness {
         let len = rng.gen_range(0..512);
 
-        let mut data = alloc::vec![0u8; len];
+        let mut data = vec![0u8; len];
         rng.fill_bytes(data.as_mut_slice());
 
         data.into()

--- a/src/transaction/validation/error.rs
+++ b/src/transaction/validation/error.rs
@@ -17,9 +17,6 @@ pub enum ValidationError {
     InputCoinPredicateDataLength {
         index: usize,
     },
-    InputCoinPredicateOwner {
-        index: usize,
-    },
     InputCoinWitnessIndexBounds {
         index: usize,
     },

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -10,7 +10,3 @@ fuel-crypto = { version = "0.4", default-features = false, features = ["random"]
 fuel-tx = { path = "../../fuel-tx", default-features = false, features = ["alloc","builder","internals","random"] }
 fuel-types = { version = "0.3", default-features = false, features = ["random"] }
 rand = { version = "0.8", default-features = false }
-
-[features]
-default = ["std"]
-std = ["fuel-tx/default", "fuel-types/default"]

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -1,25 +1,15 @@
-#![cfg_attr(not(feature = "std"), no_std)]
+#![no_std]
 
 extern crate alloc;
 
-use rand::Rng;
-
-#[cfg(feature = "std")]
-pub use use_std::*;
+use fuel_crypto::SecretKey;
+use fuel_tx::{Input, Output, Transaction, TransactionBuilder};
+use fuel_types::bytes::Deserializable;
+use rand::distributions::{Distribution, Uniform};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
 
 use alloc::vec::Vec;
-
-pub fn generate_nonempty_bytes<R>(rng: &mut R) -> Vec<u8>
-where
-    R: Rng,
-{
-    let len = rng.gen_range(1..512);
-
-    let mut data = alloc::vec![0u8; len];
-    rng.fill_bytes(data.as_mut_slice());
-
-    data.into()
-}
 
 pub fn generate_bytes<R>(rng: &mut R) -> Vec<u8>
 where
@@ -33,203 +23,178 @@ where
     data.into()
 }
 
-#[cfg(feature = "std")]
-mod use_std {
-    use fuel_crypto::SecretKey;
-    use fuel_tx::{Input, Output, Transaction, TransactionBuilder};
-    use fuel_types::bytes::Deserializable;
-    use rand::distributions::{Distribution, Uniform};
-    use rand::rngs::StdRng;
-    use rand::{Rng, SeedableRng};
+pub struct TransactionFactory<R>
+where
+    R: Rng,
+{
+    rng: R,
+    input_sampler: Uniform<usize>,
+    output_sampler: Uniform<usize>,
+    tx_sampler: Uniform<usize>,
+}
 
-    use crate::{generate_bytes, generate_nonempty_bytes};
+impl<R> From<R> for TransactionFactory<R>
+where
+    R: Rng,
+{
+    fn from(rng: R) -> Self {
+        let tx_sampler = Uniform::from(0..2);
+        let input_sampler = Uniform::from(0..2);
+        let output_sampler = Uniform::from(0..6);
 
-    pub struct TransactionFactory<R>
-    where
-        R: Rng,
-    {
-        rng: R,
-        input_sampler: Uniform<usize>,
-        output_sampler: Uniform<usize>,
-        tx_sampler: Uniform<usize>,
+        // Trick to enforce coverage of all variants in compile-time
+        //
+        // When and if a new variant is added, this implementation enforces it will be
+        // listed here.
+        debug_assert!({
+            Input::from_bytes(&[])
+                .map(|i| match i {
+                    Input::Coin { .. } => (),
+                    Input::Contract { .. } => (),
+                })
+                .unwrap_or(());
+
+            Output::from_bytes(&[])
+                .map(|o| match o {
+                    Output::Coin { .. } => (),
+                    Output::Contract { .. } => (),
+                    Output::Withdrawal { .. } => (),
+                    Output::Change { .. } => (),
+                    Output::Variable { .. } => (),
+                    Output::ContractCreated { .. } => (),
+                })
+                .unwrap_or(());
+
+            Transaction::from_bytes(&[])
+                .map(|t| match t {
+                    Transaction::Script { .. } => (),
+                    Transaction::Create { .. } => (),
+                })
+                .unwrap_or(());
+
+            true
+        });
+
+        Self {
+            rng,
+            tx_sampler,
+            input_sampler,
+            output_sampler,
+        }
+    }
+}
+
+impl TransactionFactory<StdRng> {
+    pub fn from_seed(seed: u64) -> Self {
+        StdRng::seed_from_u64(seed).into()
+    }
+}
+
+impl<R> TransactionFactory<R>
+where
+    R: Rng,
+{
+    pub fn transaction(&mut self) -> Transaction {
+        self.transaction_with_keys().0
     }
 
-    impl<R> From<R> for TransactionFactory<R>
-    where
-        R: Rng,
-    {
-        fn from(rng: R) -> Self {
-            let tx_sampler = Uniform::from(0..2);
-            let input_sampler = Uniform::from(0..3);
-            let output_sampler = Uniform::from(0..6);
+    pub fn transaction_with_keys(&mut self) -> (Transaction, Vec<SecretKey>) {
+        let variant = self.tx_sampler.sample(&mut self.rng);
 
-            // Trick to enforce coverage of all variants in compile-time
-            //
-            // When and if a new variant is added, this implementation enforces it will be
-            // listed here.
-            debug_assert!({
-                Input::from_bytes(&[])
-                    .map(|i| match i {
-                        Input::CoinSigned { .. } => (),
-                        Input::CoinPredicate { .. } => (),
-                        Input::Contract { .. } => (),
-                    })
-                    .unwrap_or(());
+        let contracts = self.rng.gen_range(0..10);
+        let slots = self.rng.gen_range(0..10);
+        let mut builder = match variant {
+            0 => TransactionBuilder::script(
+                generate_bytes(&mut self.rng),
+                generate_bytes(&mut self.rng),
+            ),
+            1 => TransactionBuilder::create(
+                self.rng.gen(),
+                self.rng.gen(),
+                (0..contracts).map(|_| self.rng.gen()).collect(),
+                (0..slots).map(|_| self.rng.gen()).collect(),
+            ),
+            _ => unreachable!(),
+        };
 
-                Output::from_bytes(&[])
-                    .map(|o| match o {
-                        Output::Coin { .. } => (),
-                        Output::Contract { .. } => (),
-                        Output::Withdrawal { .. } => (),
-                        Output::Change { .. } => (),
-                        Output::Variable { .. } => (),
-                        Output::ContractCreated { .. } => (),
-                    })
-                    .unwrap_or(());
+        let inputs = self.rng.gen_range(0..10);
+        let mut input_keys = Vec::with_capacity(10);
 
-                Transaction::from_bytes(&[])
-                    .map(|t| match t {
-                        Transaction::Script { .. } => (),
-                        Transaction::Create { .. } => (),
-                    })
-                    .unwrap_or(());
+        for _ in 0..inputs {
+            let variant = self.input_sampler.sample(&mut self.rng);
 
-                true
-            });
+            match variant {
+                0 => {
+                    let secret = SecretKey::random(&mut self.rng);
 
-            Self {
-                rng,
-                tx_sampler,
-                input_sampler,
-                output_sampler,
+                    input_keys.push(secret);
+                }
+
+                1 => {
+                    let input = Input::contract(
+                        self.rng.gen(),
+                        self.rng.gen(),
+                        self.rng.gen(),
+                        self.rng.gen(),
+                    );
+
+                    builder.add_input(input);
+                }
+
+                _ => unreachable!(),
             }
         }
-    }
 
-    impl TransactionFactory<StdRng> {
-        pub fn from_seed(seed: u64) -> Self {
-            StdRng::seed_from_u64(seed).into()
-        }
-    }
-
-    impl<R> TransactionFactory<R>
-    where
-        R: Rng,
-    {
-        pub fn transaction(&mut self) -> Transaction {
-            self.transaction_with_keys().0
+        for i in 0..input_keys.len() {
+            builder.add_unsigned_coin_input(
+                self.rng.gen(),
+                &input_keys[i],
+                self.rng.gen(),
+                self.rng.gen(),
+                self.rng.gen(),
+                generate_bytes(&mut self.rng),
+                generate_bytes(&mut self.rng),
+            );
         }
 
-        pub fn transaction_with_keys(&mut self) -> (Transaction, Vec<SecretKey>) {
-            let variant = self.tx_sampler.sample(&mut self.rng);
+        let outputs = self.rng.gen_range(0..10);
+        for _ in 0..outputs {
+            let variant = self.output_sampler.sample(&mut self.rng);
 
-            let contracts = self.rng.gen_range(0..10);
-            let slots = self.rng.gen_range(0..10);
-            let mut builder = match variant {
-                0 => TransactionBuilder::script(
-                    generate_bytes(&mut self.rng),
-                    generate_bytes(&mut self.rng),
-                ),
-                1 => TransactionBuilder::create(
-                    self.rng.gen(),
-                    self.rng.gen(),
-                    (0..contracts).map(|_| self.rng.gen()).collect(),
-                    (0..slots).map(|_| self.rng.gen()).collect(),
-                ),
+            let output = match variant {
+                0 => Output::coin(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                1 => Output::contract(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                2 => Output::withdrawal(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                3 => Output::change(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                4 => Output::variable(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                5 => Output::contract_created(self.rng.gen(), self.rng.gen()),
+
                 _ => unreachable!(),
             };
 
-            let inputs = self.rng.gen_range(0..10);
-            let mut input_keys = Vec::with_capacity(10);
-
-            for _ in 0..inputs {
-                let variant = self.input_sampler.sample(&mut self.rng);
-
-                match variant {
-                    0 => {
-                        let secret = SecretKey::random(&mut self.rng);
-
-                        input_keys.push(secret);
-                    }
-
-                    1 => {
-                        let input = Input::coin_predicate(
-                            self.rng.gen(),
-                            self.rng.gen(),
-                            self.rng.gen(),
-                            self.rng.gen(),
-                            self.rng.gen(),
-                            generate_nonempty_bytes(&mut self.rng),
-                            generate_bytes(&mut self.rng),
-                        );
-
-                        builder.add_input(input);
-                    }
-
-                    2 => {
-                        let input = Input::contract(
-                            self.rng.gen(),
-                            self.rng.gen(),
-                            self.rng.gen(),
-                            self.rng.gen(),
-                        );
-
-                        builder.add_input(input);
-                    }
-
-                    _ => unreachable!(),
-                }
-            }
-
-            for i in 0..input_keys.len() {
-                builder.add_unsigned_coin_input(
-                    self.rng.gen(),
-                    &input_keys[i],
-                    self.rng.gen(),
-                    self.rng.gen(),
-                    self.rng.gen(),
-                );
-            }
-
-            let outputs = self.rng.gen_range(0..10);
-            for _ in 0..outputs {
-                let variant = self.output_sampler.sample(&mut self.rng);
-
-                let output = match variant {
-                    0 => Output::coin(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                    1 => Output::contract(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                    2 => Output::withdrawal(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                    3 => Output::change(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                    4 => Output::variable(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                    5 => Output::contract_created(self.rng.gen(), self.rng.gen()),
-
-                    _ => unreachable!(),
-                };
-
-                builder.add_output(output);
-            }
-
-            let witnesses = self.rng.gen_range(0..10);
-            for _ in 0..witnesses {
-                let witness = generate_bytes(&mut self.rng).into();
-
-                builder.add_witness(witness);
-            }
-
-            let tx = builder.finalize();
-
-            (tx, input_keys)
+            builder.add_output(output);
         }
+
+        let witnesses = self.rng.gen_range(0..10);
+        for _ in 0..witnesses {
+            let witness = generate_bytes(&mut self.rng).into();
+
+            builder.add_witness(witness);
+        }
+
+        let tx = builder.finalize();
+
+        (tx, input_keys)
     }
+}
 
-    impl<R> Iterator for TransactionFactory<R>
-    where
-        R: Rng,
-    {
-        type Item = (Transaction, Vec<SecretKey>);
+impl<R> Iterator for TransactionFactory<R>
+where
+    R: Rng,
+{
+    type Item = (Transaction, Vec<SecretKey>);
 
-        fn next(&mut self) -> Option<(Transaction, Vec<SecretKey>)> {
-            Some(self.transaction_with_keys())
-        }
+    fn next(&mut self) -> Option<(Transaction, Vec<SecretKey>)> {
+        Some(self.transaction_with_keys())
     }
 }

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,8 +1,7 @@
 use fuel_asm::Opcode;
-use fuel_crypto::Hasher;
 use fuel_tx::consts::MAX_GAS_PER_TX;
 use fuel_tx::*;
-use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
+use fuel_tx_test_helpers::generate_bytes;
 use fuel_types::{bytes, ContractId, Immediate24};
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
@@ -82,25 +81,49 @@ fn witness() {
 
 #[test]
 fn input() {
-    let rng = &mut StdRng::seed_from_u64(8586);
+    let mut rng_base = StdRng::seed_from_u64(8586);
+    let rng = &mut rng_base;
 
     assert_encoding_correct(&[
-        Input::coin_signed(
+        Input::coin(
             rng.gen(),
             rng.gen(),
             rng.next_u64(),
             rng.gen(),
             rng.gen(),
             rng.next_u64(),
-        ),
-        Input::coin_predicate(
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            rng.gen(),
-            rng.gen(),
-            generate_nonempty_bytes(rng),
             generate_bytes(rng),
+            generate_bytes(rng),
+        ),
+        Input::coin(
+            rng.gen(),
+            rng.gen(),
+            rng.next_u64(),
+            rng.gen(),
+            rng.gen(),
+            rng.next_u64(),
+            vec![],
+            generate_bytes(rng),
+        ),
+        Input::coin(
+            rng.gen(),
+            rng.gen(),
+            rng.next_u64(),
+            rng.gen(),
+            rng.gen(),
+            rng.next_u64(),
+            generate_bytes(rng),
+            vec![],
+        ),
+        Input::coin(
+            rng.gen(),
+            rng.gen(),
+            rng.next_u64(),
+            rng.gen(),
+            rng.gen(),
+            rng.next_u64(),
+            vec![],
+            vec![],
         ),
         Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
     ]);
@@ -671,17 +694,15 @@ fn create_input_coin_data_offset() {
         vec![generate_bytes(rng).into(), generate_bytes(rng).into()],
     ];
 
-    let predicate = generate_nonempty_bytes(rng);
+    let predicate = generate_bytes(rng);
     let predicate_data = generate_bytes(rng);
-
-    let owner = (*Hasher::hash(predicate.as_slice())).into();
-
-    let input_coin = Input::coin_predicate(
+    let input_coin = Input::coin(
         rng.gen(),
-        owner,
+        rng.gen(),
         rng.next_u64(),
         rng.gen(),
         rng.gen(),
+        rng.next_u64(),
         predicate.clone(),
         predicate_data,
     );
@@ -773,17 +794,15 @@ fn script_input_coin_data_offset() {
         vec![generate_bytes(rng).into(), generate_bytes(rng).into()],
     ];
 
-    let predicate = generate_nonempty_bytes(rng);
+    let predicate = generate_bytes(rng);
     let predicate_data = generate_bytes(rng);
-
-    let owner = (*Hasher::hash(predicate.as_slice())).into();
-
-    let input_coin = Input::coin_predicate(
+    let input_coin = Input::coin(
         rng.gen(),
-        owner,
+        rng.gen(),
         rng.next_u64(),
         rng.gen(),
         rng.gen(),
+        rng.next_u64(),
         predicate.clone(),
         predicate_data,
     );

--- a/tests/valid_cases/output.rs
+++ b/tests/valid_cases/output.rs
@@ -1,4 +1,5 @@
 use fuel_tx::*;
+use fuel_tx_test_helpers::generate_bytes;
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
 
@@ -21,13 +22,15 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin_signed(
+                Input::coin(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
+                    generate_bytes(rng),
+                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],
@@ -38,13 +41,15 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin_signed(
+                Input::coin(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
+                    generate_bytes(rng),
+                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],
@@ -57,13 +62,15 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin_signed(
+                Input::coin(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
+                    generate_bytes(rng),
+                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -170,7 +170,15 @@ fn max_iow() {
         .gas_price(rng.gen())
         .gas_limit(MAX_GAS_PER_TX)
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, maturity);
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            asset_id,
+            maturity,
+            generate_bytes(rng),
+            generate_bytes(rng),
+        );
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
         builder.add_output(Output::coin(rng.gen(), rng.gen(), asset_id));
@@ -199,7 +207,15 @@ fn max_iow() {
 
     let asset_id: AssetId = rng.gen();
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), asset_id, maturity);
+        builder.add_unsigned_coin_input(
+            rng.gen(),
+            k,
+            rng.gen(),
+            asset_id,
+            maturity,
+            generate_bytes(rng),
+            generate_bytes(rng),
+        );
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -228,7 +244,15 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
+        builder.add_unsigned_coin_input(
+            rng.gen(),
+            k,
+            rng.gen(),
+            rng.gen(),
+            maturity,
+            generate_bytes(rng),
+            generate_bytes(rng),
+        );
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -260,7 +284,15 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
+        builder.add_unsigned_coin_input(
+            rng.gen(),
+            k,
+            rng.gen(),
+            rng.gen(),
+            maturity,
+            generate_bytes(rng),
+            generate_bytes(rng),
+        );
     });
 
     while builder.outputs().len() < 1 + MAX_OUTPUTS as usize {
@@ -292,7 +324,15 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
+        builder.add_unsigned_coin_input(
+            rng.gen(),
+            k,
+            rng.gen(),
+            rng.gen(),
+            maturity,
+            generate_bytes(rng),
+            generate_bytes(rng),
+        );
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -329,8 +369,24 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            a,
+            rng.gen(),
+            generate_bytes(rng),
+            generate_bytes(rng),
+        )
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            b,
+            rng.gen(),
+            generate_bytes(rng),
+            generate_bytes(rng),
+        )
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), b))
         .finalize()
@@ -341,8 +397,24 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            a,
+            rng.gen(),
+            generate_bytes(rng),
+            generate_bytes(rng),
+        )
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            b,
+            rng.gen(),
+            generate_bytes(rng),
+            generate_bytes(rng),
+        )
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .finalize()
@@ -359,8 +431,24 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            a,
+            rng.gen(),
+            generate_bytes(rng),
+            generate_bytes(rng),
+        )
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            b,
+            rng.gen(),
+            generate_bytes(rng),
+            generate_bytes(rng),
+        )
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), c))
         .finalize()
@@ -377,8 +465,24 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            a,
+            rng.gen(),
+            generate_bytes(rng),
+            generate_bytes(rng),
+        )
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            b,
+            rng.gen(),
+            generate_bytes(rng),
+            generate_bytes(rng),
+        )
         .add_output(Output::coin(rng.gen(), rng.next_u64(), a))
         .add_output(Output::coin(rng.gen(), rng.next_u64(), c))
         .finalize()
@@ -409,7 +513,15 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
+    .add_unsigned_coin_input(
+        rng.gen(),
+        &secret,
+        rng.gen(),
+        asset_id,
+        rng.gen(),
+        generate_bytes(rng),
+        generate_bytes(rng),
+    )
     .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
     .finalize()
     .validate(block_height)
@@ -422,7 +534,15 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
+    .add_unsigned_coin_input(
+        rng.gen(),
+        &secret,
+        rng.gen(),
+        asset_id,
+        rng.gen(),
+        generate_bytes(rng),
+        generate_bytes(rng),
+    )
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -441,7 +561,15 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
+    .add_unsigned_coin_input(
+        rng.gen(),
+        &secret,
+        rng.gen(),
+        asset_id,
+        rng.gen(),
+        generate_bytes(rng),
+        generate_bytes(rng),
+    )
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -457,7 +585,15 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
+    .add_unsigned_coin_input(
+        rng.gen(),
+        &secret,
+        rng.gen(),
+        asset_id,
+        rng.gen(),
+        generate_bytes(rng),
+        generate_bytes(rng),
+    )
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -481,7 +617,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), rng.gen(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            rng.gen(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .finalize()
         .validate(block_height)
         .expect("Failed to validate tx");
@@ -507,7 +651,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), rng.gen(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            rng.gen(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::variable(rng.gen(), rng.gen(), rng.gen()))
         .finalize()
         .validate(block_height)
@@ -523,8 +675,24 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), rng.gen(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret_b,
+            rng.gen(),
+            rng.gen(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
@@ -543,8 +711,24 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), asset_id, maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret_b,
+            rng.gen(),
+            asset_id,
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
         .finalize()
@@ -561,8 +745,24 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), rng.gen(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret_b,
+            rng.gen(),
+            rng.gen(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .finalize()
@@ -579,7 +779,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_witness(vec![0xfa; CONTRACT_MAX_SIZE as usize / 4].into())
         .finalize()
@@ -590,7 +798,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_witness(vec![0xfa; 1 + CONTRACT_MAX_SIZE as usize].into())
         .finalize()
@@ -604,7 +820,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_witness(vec![0xfa; CONTRACT_MAX_SIZE as usize / 4].into())
         .finalize()
@@ -631,7 +855,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)
@@ -647,7 +879,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)
@@ -667,7 +907,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)
@@ -700,7 +948,15 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+    .add_unsigned_coin_input(
+        rng.gen(),
+        &secret,
+        rng.gen(),
+        AssetId::default(),
+        maturity,
+        vec![],
+        vec![],
+    )
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -716,7 +972,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)
@@ -734,7 +998,15 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(
+            rng.gen(),
+            &secret,
+            rng.gen(),
+            AssetId::default(),
+            maturity,
+            vec![],
+            vec![],
+        )
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height)


### PR DESCRIPTION
Reverts FuelLabs/fuel-tx#111

This is major breaking change and we'd like to keep it on a feature branch for now so that we don't block the critical path of releasing the dev net.