### PR TITLE
Non-Exhaustive Validation Errors

### DIFF
--- a/src/transaction/validation/error.rs
+++ b/src/transaction/validation/error.rs
@@ -10,6 +10,7 @@ use std::{error, io};
     feature = "serde-types-minimal",
     derive(serde::Serialize, serde::Deserialize)
 )]
+#[non_exhaustive]
 pub enum ValidationError {
     InputCoinPredicateLength {
         index: usize,


### PR DESCRIPTION
Make validation errors non-exhaustive so that additional future errors are non-breaking. Typically users only care about whether a validation error occurred or not, and don't attempt to match on every possible variant.