### PR TITLE
Split `Input::coin` into predicate and signed (#111)

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -158,7 +158,9 @@ impl Transaction {
 
     pub fn input_asset_ids(&self) -> impl Iterator<Item = &AssetId> {
         self.inputs().iter().filter_map(|input| match input {
-            Input::Coin { asset_id, .. } => Some(asset_id),
+            Input::CoinPredicate { asset_id, .. } | Input::CoinSigned { asset_id, .. } => {
+                Some(asset_id)
+            }
             _ => None,
         })
     }
@@ -316,22 +318,11 @@ impl Transaction {
         amount: Word,
         asset_id: AssetId,
         maturity: Word,
-        predicate: Vec<u8>,
-        predicate_data: Vec<u8>,
     ) {
         let owner = Input::coin_owner(owner);
 
         let witness_index = self.witnesses().len() as u8;
-        let input = Input::coin(
-            utxo_id,
-            owner,
-            amount,
-            asset_id,
-            witness_index,
-            maturity,
-            predicate,
-            predicate_data,
-        );
+        let input = Input::coin_signed(utxo_id, owner, amount, asset_id, witness_index, maturity);
 
         self._add_witness(Witness::default());
         self._add_input(input);
@@ -364,7 +355,7 @@ impl Transaction {
         inputs
             .iter()
             .filter_map(|input| match input {
-                Input::Coin {
+                Input::CoinSigned {
                     owner,
                     witness_index,
                     ..

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -107,7 +107,7 @@ mod tests {
     use crate::consts::MAX_GAS_PER_TX;
     use crate::*;
 
-    use fuel_tx_test_helpers::generate_bytes;
+    use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
     use rand::rngs::StdRng;
     use rand::{Rng, RngCore, SeedableRng};
     use std::io::{Read, Write};
@@ -213,14 +213,26 @@ mod tests {
         assert_id_ne(tx, |t| t.set_maturity(t.maturity().not()));
 
         if !tx.inputs().is_empty() {
-            assert_io_ne!(tx, inputs_mut, Input::Coin, utxo_id, invert_utxo_id);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, owner, invert);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, amount, not);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, asset_id, invert);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, witness_index, not);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, maturity, not);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, predicate, inv_v);
-            assert_io_ne!(tx, inputs_mut, Input::Coin, predicate_data, inv_v);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, utxo_id, invert_utxo_id);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, owner, invert);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, amount, not);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, asset_id, invert);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, witness_index, not);
+            assert_io_ne!(tx, inputs_mut, Input::CoinSigned, maturity, not);
+
+            assert_io_ne!(
+                tx,
+                inputs_mut,
+                Input::CoinPredicate,
+                utxo_id,
+                invert_utxo_id
+            );
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, owner, invert);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, amount, not);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, asset_id, invert);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, maturity, not);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, predicate, inv_v);
+            assert_io_ne!(tx, inputs_mut, Input::CoinPredicate, predicate_data, inv_v);
 
             assert_io_eq!(tx, inputs_mut, Input::Contract, utxo_id, invert_utxo_id);
             assert_io_eq!(tx, inputs_mut, Input::Contract, balance_root, invert);
@@ -272,14 +284,21 @@ mod tests {
         let inputs = vec![
             vec![],
             vec![
-                Input::coin(
+                Input::coin_signed(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                    generate_bytes(rng),
+                ),
+                Input::coin_predicate(
+                    rng.gen(),
+                    rng.gen(),
+                    rng.next_u64(),
+                    rng.gen(),
+                    rng.next_u64(),
+                    generate_nonempty_bytes(rng),
                     generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),

--- a/src/transaction/internals.rs
+++ b/src/transaction/internals.rs
@@ -1,7 +1,26 @@
 use crate::{Input, Output, Transaction, Witness};
 
-use alloc::vec::Vec;
 use fuel_asm::Word;
+use itertools::Itertools;
+
+use alloc::vec::Vec;
+use core::hash::Hash;
+
+pub(crate) fn next_duplicate<U>(iter: impl Iterator<Item = U>) -> Option<U>
+where
+    U: PartialEq + Ord + Copy + Hash,
+{
+    #[cfg(not(feature = "std"))]
+    return iter
+        .sorted()
+        .as_slice()
+        .windows(2)
+        .filter_map(|u| (u[0] == u[1]).then(|| u[0]))
+        .next();
+
+    #[cfg(feature = "std")]
+    return iter.duplicates().next();
+}
 
 #[cfg(feature = "internals")]
 impl Transaction {

--- a/src/transaction/offset.rs
+++ b/src/transaction/offset.rs
@@ -31,7 +31,7 @@ impl Transaction {
 
     /// For a transaction of type `Create`, return the offset of the data
     /// relative to the serialized transaction for a given index of inputs,
-    /// if this input is of type `Coin`.
+    /// if this input is of type `CoinPredicate`.
     pub fn input_coin_predicate_offset(&self, index: usize) -> Option<usize> {
         self.metadata()
             .map(|m| m.input_coin_predicate_offset(index))
@@ -41,7 +41,7 @@ impl Transaction {
     pub(crate) fn _input_coin_predicate_offset(&self, index: usize) -> Option<usize> {
         self.input_offset(index)
             .map(|ofs| ofs + Input::coin_predicate_offset())
-            .filter(|_| self.inputs()[index].is_coin())
+            .filter(|_| self.inputs()[index].is_coin_predicate())
     }
 
     /// Return the serialized bytes offset of the input with the provided index

--- a/src/transaction/types/utxo_id.rs
+++ b/src/transaction/types/utxo_id.rs
@@ -11,7 +11,7 @@ use rand::{
 };
 
 /// Identification of unspend transaction output.
-#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Debug, Default, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct UtxoId {
     /// transaction id

--- a/src/transaction/types/witness.rs
+++ b/src/transaction/types/witness.rs
@@ -66,7 +66,7 @@ impl Distribution<Witness> for Standard {
     fn sample<R: Rng + ?Sized>(&self, rng: &mut R) -> Witness {
         let len = rng.gen_range(0..512);
 
-        let mut data = vec![0u8; len];
+        let mut data = alloc::vec![0u8; len];
         rng.fill_bytes(data.as_mut_slice());
 
         data.into()

--- a/src/transaction/validation/error.rs
+++ b/src/transaction/validation/error.rs
@@ -15,6 +15,9 @@ pub enum ValidationError {
     InputCoinPredicateDataLength {
         index: usize,
     },
+    InputCoinPredicateOwner {
+        index: usize,
+    },
     InputCoinWitnessIndexBounds {
         index: usize,
     },

--- a/test-helpers/Cargo.toml
+++ b/test-helpers/Cargo.toml
@@ -10,3 +10,7 @@ fuel-crypto = { version = "0.5", default-features = false, features = ["random"]
 fuel-tx = { path = "../../fuel-tx", default-features = false, features = ["alloc","builder","internals","random"] }
 fuel-types = { version = "0.5", default-features = false, features = ["random"] }
 rand = { version = "0.8", default-features = false }
+
+[features]
+default = ["std"]
+std = ["fuel-tx/default", "fuel-types/default"]

--- a/test-helpers/src/lib.rs
+++ b/test-helpers/src/lib.rs
@@ -1,15 +1,25 @@
-#![no_std]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 extern crate alloc;
 
-use fuel_crypto::SecretKey;
-use fuel_tx::{Input, Output, Transaction, TransactionBuilder};
-use fuel_types::bytes::Deserializable;
-use rand::distributions::{Distribution, Uniform};
-use rand::rngs::StdRng;
-use rand::{Rng, SeedableRng};
+use rand::Rng;
+
+#[cfg(feature = "std")]
+pub use use_std::*;
 
 use alloc::vec::Vec;
+
+pub fn generate_nonempty_bytes<R>(rng: &mut R) -> Vec<u8>
+where
+    R: Rng,
+{
+    let len = rng.gen_range(1..512);
+
+    let mut data = alloc::vec![0u8; len];
+    rng.fill_bytes(data.as_mut_slice());
+
+    data.into()
+}
 
 pub fn generate_bytes<R>(rng: &mut R) -> Vec<u8>
 where
@@ -23,178 +33,203 @@ where
     data.into()
 }
 
-pub struct TransactionFactory<R>
-where
-    R: Rng,
-{
-    rng: R,
-    input_sampler: Uniform<usize>,
-    output_sampler: Uniform<usize>,
-    tx_sampler: Uniform<usize>,
-}
+#[cfg(feature = "std")]
+mod use_std {
+    use fuel_crypto::SecretKey;
+    use fuel_tx::{Input, Output, Transaction, TransactionBuilder};
+    use fuel_types::bytes::Deserializable;
+    use rand::distributions::{Distribution, Uniform};
+    use rand::rngs::StdRng;
+    use rand::{Rng, SeedableRng};
 
-impl<R> From<R> for TransactionFactory<R>
-where
-    R: Rng,
-{
-    fn from(rng: R) -> Self {
-        let tx_sampler = Uniform::from(0..2);
-        let input_sampler = Uniform::from(0..2);
-        let output_sampler = Uniform::from(0..6);
+    use crate::{generate_bytes, generate_nonempty_bytes};
 
-        // Trick to enforce coverage of all variants in compile-time
-        //
-        // When and if a new variant is added, this implementation enforces it will be
-        // listed here.
-        debug_assert!({
-            Input::from_bytes(&[])
-                .map(|i| match i {
-                    Input::Coin { .. } => (),
-                    Input::Contract { .. } => (),
-                })
-                .unwrap_or(());
-
-            Output::from_bytes(&[])
-                .map(|o| match o {
-                    Output::Coin { .. } => (),
-                    Output::Contract { .. } => (),
-                    Output::Withdrawal { .. } => (),
-                    Output::Change { .. } => (),
-                    Output::Variable { .. } => (),
-                    Output::ContractCreated { .. } => (),
-                })
-                .unwrap_or(());
-
-            Transaction::from_bytes(&[])
-                .map(|t| match t {
-                    Transaction::Script { .. } => (),
-                    Transaction::Create { .. } => (),
-                })
-                .unwrap_or(());
-
-            true
-        });
-
-        Self {
-            rng,
-            tx_sampler,
-            input_sampler,
-            output_sampler,
-        }
-    }
-}
-
-impl TransactionFactory<StdRng> {
-    pub fn from_seed(seed: u64) -> Self {
-        StdRng::seed_from_u64(seed).into()
-    }
-}
-
-impl<R> TransactionFactory<R>
-where
-    R: Rng,
-{
-    pub fn transaction(&mut self) -> Transaction {
-        self.transaction_with_keys().0
+    pub struct TransactionFactory<R>
+    where
+        R: Rng,
+    {
+        rng: R,
+        input_sampler: Uniform<usize>,
+        output_sampler: Uniform<usize>,
+        tx_sampler: Uniform<usize>,
     }
 
-    pub fn transaction_with_keys(&mut self) -> (Transaction, Vec<SecretKey>) {
-        let variant = self.tx_sampler.sample(&mut self.rng);
+    impl<R> From<R> for TransactionFactory<R>
+    where
+        R: Rng,
+    {
+        fn from(rng: R) -> Self {
+            let tx_sampler = Uniform::from(0..2);
+            let input_sampler = Uniform::from(0..3);
+            let output_sampler = Uniform::from(0..6);
 
-        let contracts = self.rng.gen_range(0..10);
-        let slots = self.rng.gen_range(0..10);
-        let mut builder = match variant {
-            0 => TransactionBuilder::script(
-                generate_bytes(&mut self.rng),
-                generate_bytes(&mut self.rng),
-            ),
-            1 => TransactionBuilder::create(
-                self.rng.gen(),
-                self.rng.gen(),
-                (0..contracts).map(|_| self.rng.gen()).collect(),
-                (0..slots).map(|_| self.rng.gen()).collect(),
-            ),
-            _ => unreachable!(),
-        };
+            // Trick to enforce coverage of all variants in compile-time
+            //
+            // When and if a new variant is added, this implementation enforces it will be
+            // listed here.
+            debug_assert!({
+                Input::from_bytes(&[])
+                    .map(|i| match i {
+                        Input::CoinSigned { .. } => (),
+                        Input::CoinPredicate { .. } => (),
+                        Input::Contract { .. } => (),
+                    })
+                    .unwrap_or(());
 
-        let inputs = self.rng.gen_range(0..10);
-        let mut input_keys = Vec::with_capacity(10);
+                Output::from_bytes(&[])
+                    .map(|o| match o {
+                        Output::Coin { .. } => (),
+                        Output::Contract { .. } => (),
+                        Output::Withdrawal { .. } => (),
+                        Output::Change { .. } => (),
+                        Output::Variable { .. } => (),
+                        Output::ContractCreated { .. } => (),
+                    })
+                    .unwrap_or(());
 
-        for _ in 0..inputs {
-            let variant = self.input_sampler.sample(&mut self.rng);
+                Transaction::from_bytes(&[])
+                    .map(|t| match t {
+                        Transaction::Script { .. } => (),
+                        Transaction::Create { .. } => (),
+                    })
+                    .unwrap_or(());
 
-            match variant {
-                0 => {
-                    let secret = SecretKey::random(&mut self.rng);
+                true
+            });
 
-                    input_keys.push(secret);
-                }
-
-                1 => {
-                    let input = Input::contract(
-                        self.rng.gen(),
-                        self.rng.gen(),
-                        self.rng.gen(),
-                        self.rng.gen(),
-                    );
-
-                    builder.add_input(input);
-                }
-
-                _ => unreachable!(),
+            Self {
+                rng,
+                tx_sampler,
+                input_sampler,
+                output_sampler,
             }
         }
+    }
 
-        for i in 0..input_keys.len() {
-            builder.add_unsigned_coin_input(
-                self.rng.gen(),
-                &input_keys[i],
-                self.rng.gen(),
-                self.rng.gen(),
-                self.rng.gen(),
-                generate_bytes(&mut self.rng),
-                generate_bytes(&mut self.rng),
-            );
+    impl TransactionFactory<StdRng> {
+        pub fn from_seed(seed: u64) -> Self {
+            StdRng::seed_from_u64(seed).into()
+        }
+    }
+
+    impl<R> TransactionFactory<R>
+    where
+        R: Rng,
+    {
+        pub fn transaction(&mut self) -> Transaction {
+            self.transaction_with_keys().0
         }
 
-        let outputs = self.rng.gen_range(0..10);
-        for _ in 0..outputs {
-            let variant = self.output_sampler.sample(&mut self.rng);
+        pub fn transaction_with_keys(&mut self) -> (Transaction, Vec<SecretKey>) {
+            let variant = self.tx_sampler.sample(&mut self.rng);
 
-            let output = match variant {
-                0 => Output::coin(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                1 => Output::contract(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                2 => Output::withdrawal(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                3 => Output::change(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                4 => Output::variable(self.rng.gen(), self.rng.gen(), self.rng.gen()),
-                5 => Output::contract_created(self.rng.gen(), self.rng.gen()),
-
+            let contracts = self.rng.gen_range(0..10);
+            let slots = self.rng.gen_range(0..10);
+            let mut builder = match variant {
+                0 => TransactionBuilder::script(
+                    generate_bytes(&mut self.rng),
+                    generate_bytes(&mut self.rng),
+                ),
+                1 => TransactionBuilder::create(
+                    self.rng.gen(),
+                    self.rng.gen(),
+                    (0..contracts).map(|_| self.rng.gen()).collect(),
+                    (0..slots).map(|_| self.rng.gen()).collect(),
+                ),
                 _ => unreachable!(),
             };
 
-            builder.add_output(output);
+            let inputs = self.rng.gen_range(0..10);
+            let mut input_keys = Vec::with_capacity(10);
+
+            for _ in 0..inputs {
+                let variant = self.input_sampler.sample(&mut self.rng);
+
+                match variant {
+                    0 => {
+                        let secret = SecretKey::random(&mut self.rng);
+
+                        input_keys.push(secret);
+                    }
+
+                    1 => {
+                        let input = Input::coin_predicate(
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            generate_nonempty_bytes(&mut self.rng),
+                            generate_bytes(&mut self.rng),
+                        );
+
+                        builder.add_input(input);
+                    }
+
+                    2 => {
+                        let input = Input::contract(
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                            self.rng.gen(),
+                        );
+
+                        builder.add_input(input);
+                    }
+
+                    _ => unreachable!(),
+                }
+            }
+
+            for i in 0..input_keys.len() {
+                builder.add_unsigned_coin_input(
+                    self.rng.gen(),
+                    &input_keys[i],
+                    self.rng.gen(),
+                    self.rng.gen(),
+                    self.rng.gen(),
+                );
+            }
+
+            let outputs = self.rng.gen_range(0..10);
+            for _ in 0..outputs {
+                let variant = self.output_sampler.sample(&mut self.rng);
+
+                let output = match variant {
+                    0 => Output::coin(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    1 => Output::contract(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    2 => Output::withdrawal(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    3 => Output::change(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    4 => Output::variable(self.rng.gen(), self.rng.gen(), self.rng.gen()),
+                    5 => Output::contract_created(self.rng.gen(), self.rng.gen()),
+
+                    _ => unreachable!(),
+                };
+
+                builder.add_output(output);
+            }
+
+            let witnesses = self.rng.gen_range(0..10);
+            for _ in 0..witnesses {
+                let witness = generate_bytes(&mut self.rng).into();
+
+                builder.add_witness(witness);
+            }
+
+            let tx = builder.finalize();
+
+            (tx, input_keys)
         }
-
-        let witnesses = self.rng.gen_range(0..10);
-        for _ in 0..witnesses {
-            let witness = generate_bytes(&mut self.rng).into();
-
-            builder.add_witness(witness);
-        }
-
-        let tx = builder.finalize();
-
-        (tx, input_keys)
     }
-}
 
-impl<R> Iterator for TransactionFactory<R>
-where
-    R: Rng,
-{
-    type Item = (Transaction, Vec<SecretKey>);
+    impl<R> Iterator for TransactionFactory<R>
+    where
+        R: Rng,
+    {
+        type Item = (Transaction, Vec<SecretKey>);
 
-    fn next(&mut self) -> Option<(Transaction, Vec<SecretKey>)> {
-        Some(self.transaction_with_keys())
+        fn next(&mut self) -> Option<(Transaction, Vec<SecretKey>)> {
+            Some(self.transaction_with_keys())
+        }
     }
 }

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,7 +1,8 @@
 use fuel_asm::Opcode;
+use fuel_crypto::Hasher;
 use fuel_tx::consts::MAX_GAS_PER_TX;
 use fuel_tx::*;
-use fuel_tx_test_helpers::generate_bytes;
+use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
 use fuel_types::{bytes, ContractId, Immediate24};
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
@@ -93,45 +94,22 @@ fn input() {
     let rng = &mut StdRng::seed_from_u64(8586);
 
     assert_encoding_correct(&[
-        Input::coin(
+        Input::coin_signed(
             rng.gen(),
             rng.gen(),
             rng.next_u64(),
             rng.gen(),
             rng.gen(),
             rng.next_u64(),
-            generate_bytes(rng),
-            generate_bytes(rng),
         ),
-        Input::coin(
+        Input::coin_predicate(
             rng.gen(),
             rng.gen(),
             rng.next_u64(),
             rng.gen(),
             rng.gen(),
-            rng.next_u64(),
-            vec![],
+            generate_nonempty_bytes(rng),
             generate_bytes(rng),
-        ),
-        Input::coin(
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            generate_bytes(rng),
-            vec![],
-        ),
-        Input::coin(
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            rng.gen(),
-            rng.gen(),
-            rng.next_u64(),
-            vec![],
-            vec![],
         ),
         Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
     ]);
@@ -699,15 +677,17 @@ fn create_input_coin_data_offset() {
         vec![generate_bytes(rng).into(), generate_bytes(rng).into()],
     ];
 
-    let predicate = generate_bytes(rng);
+    let predicate = generate_nonempty_bytes(rng);
     let predicate_data = generate_bytes(rng);
-    let input_coin = Input::coin(
+
+    let owner = (*Hasher::hash(predicate.as_slice())).into();
+
+    let input_coin = Input::coin_predicate(
         rng.gen(),
-        rng.gen(),
+        owner,
         rng.next_u64(),
         rng.gen(),
         rng.gen(),
-        rng.next_u64(),
         predicate.clone(),
         predicate_data,
     );
@@ -798,15 +778,17 @@ fn script_input_coin_data_offset() {
         vec![generate_bytes(rng).into(), generate_bytes(rng).into()],
     ];
 
-    let predicate = generate_bytes(rng);
+    let predicate = generate_nonempty_bytes(rng);
     let predicate_data = generate_bytes(rng);
-    let input_coin = Input::coin(
+
+    let owner = (*Hasher::hash(predicate.as_slice())).into();
+
+    let input_coin = Input::coin_predicate(
         rng.gen(),
-        rng.gen(),
+        owner,
         rng.next_u64(),
         rng.gen(),
         rng.gen(),
-        rng.next_u64(),
         predicate.clone(),
         predicate_data,
     );

--- a/tests/valid_cases/output.rs
+++ b/tests/valid_cases/output.rs
@@ -1,5 +1,4 @@
 use fuel_tx::*;
-use fuel_tx_test_helpers::generate_bytes;
 use rand::rngs::StdRng;
 use rand::{Rng, RngCore, SeedableRng};
 
@@ -22,15 +21,13 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin(
+                Input::coin_signed(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                    generate_bytes(rng),
-                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],
@@ -41,15 +38,13 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin(
+                Input::coin_signed(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                    generate_bytes(rng),
-                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],
@@ -62,15 +57,13 @@ fn contract() {
         .validate(
             2,
             &[
-                Input::coin(
+                Input::coin_signed(
                     rng.gen(),
                     rng.gen(),
                     rng.next_u64(),
                     rng.gen(),
                     rng.next_u32().to_be_bytes()[0],
                     rng.next_u64(),
-                    generate_bytes(rng),
-                    generate_bytes(rng),
                 ),
                 Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()),
             ],

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -172,15 +172,7 @@ fn max_iow() {
         .gas_price(rng.gen())
         .gas_limit(MAX_GAS_PER_TX)
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            asset_id,
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, maturity);
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
         builder.add_output(Output::coin(rng.gen(), rng.gen(), asset_id));
@@ -211,15 +203,7 @@ fn max_iow() {
 
     let asset_id: AssetId = rng.gen();
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(
-            rng.gen(),
-            k,
-            rng.gen(),
-            asset_id,
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), asset_id, maturity);
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -249,15 +233,7 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(
-            rng.gen(),
-            k,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -290,15 +266,7 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(
-            rng.gen(),
-            k,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
     });
 
     while builder.outputs().len() < 1 + MAX_OUTPUTS as usize {
@@ -331,15 +299,7 @@ fn max_iow() {
         .collect();
 
     secrets.iter().for_each(|k| {
-        builder.add_unsigned_coin_input(
-            rng.gen(),
-            k,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            generate_bytes(rng),
-            generate_bytes(rng),
-        );
+        builder.add_unsigned_coin_input(rng.gen(), k, rng.gen(), rng.gen(), maturity);
     });
 
     while builder.outputs().len() < MAX_OUTPUTS as usize {
@@ -376,24 +336,8 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            a,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            b,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), b))
         .finalize()
@@ -404,24 +348,8 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            a,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            b,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .finalize()
@@ -438,24 +366,8 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            a,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            b,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), c))
         .finalize()
@@ -472,24 +384,8 @@ fn output_change_asset_id() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            a,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            b,
-            rng.gen(),
-            generate_bytes(rng),
-            generate_bytes(rng),
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), a, rng.gen())
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), b, rng.gen())
         .add_output(Output::coin(rng.gen(), rng.next_u64(), a))
         .add_output(Output::coin(rng.gen(), rng.next_u64(), c))
         .finalize()
@@ -520,15 +416,7 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        asset_id,
-        rng.gen(),
-        generate_bytes(rng),
-        generate_bytes(rng),
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
     .finalize()
     .validate(block_height)
@@ -541,15 +429,7 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        asset_id,
-        rng.gen(),
-        generate_bytes(rng),
-        generate_bytes(rng),
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -568,15 +448,7 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        asset_id,
-        rng.gen(),
-        generate_bytes(rng),
-        generate_bytes(rng),
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -592,15 +464,7 @@ fn script() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        asset_id,
-        rng.gen(),
-        generate_bytes(rng),
-        generate_bytes(rng),
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height)
@@ -624,15 +488,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), rng.gen(), maturity)
         .finalize()
         .validate(block_height)
         .expect("Failed to validate tx");
@@ -657,15 +513,7 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), rng.gen(), maturity)
         .add_output(Output::variable(rng.gen(), rng.gen(), rng.gen()))
         .finalize()
         .validate(block_height)
@@ -681,24 +529,8 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret_b,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), rng.gen(), maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
@@ -717,24 +549,8 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret_b,
-            rng.gen(),
-            asset_id,
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), asset_id, maturity)
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
         .finalize()
@@ -751,24 +567,8 @@ fn create() {
         .gas_limit(MAX_GAS_PER_TX)
         .gas_price(rng.gen())
         .maturity(maturity)
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret,
-            rng.gen(),
-            AssetId::default(),
-            maturity,
-            vec![],
-            vec![],
-        )
-        .add_unsigned_coin_input(
-            rng.gen(),
-            &secret_b,
-            rng.gen(),
-            rng.gen(),
-            maturity,
-            vec![],
-            vec![],
-        )
+        .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
+        .add_unsigned_coin_input(rng.gen(), &secret_b, rng.gen(), rng.gen(), maturity)
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .finalize()
@@ -790,15 +590,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -813,15 +605,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -868,15 +652,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -897,15 +673,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -927,15 +695,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -965,15 +725,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -994,15 +746,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)
@@ -1025,15 +769,7 @@ fn create() {
     .gas_limit(MAX_GAS_PER_TX)
     .gas_price(rng.gen())
     .maturity(maturity)
-    .add_unsigned_coin_input(
-        rng.gen(),
-        &secret,
-        rng.gen(),
-        AssetId::default(),
-        maturity,
-        vec![],
-        vec![],
-    )
+    .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height)


### PR DESCRIPTION
The input coin defined in the specifications is an aggregated type
between two logical variants: signed and predicate.

When the input is expected to behave as coin, the signature validation
should seek its witness counterpart and check the signature with its
fields as arguments = except for predicate and its data.

When the input is expected to behave as predicate, the validation will
check if the owner is the hash of the predicate. The witness id is
entirely ignored.

It is canonical to Rust to split these two different logical structures
into different enum variants - even if we are to maintain the fuel specs
canonical serialization.

Closes #110