### PR TITLE
Update contract initial state root to SMT

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,10 @@ fuel-crypto = { version = "0.5", default-features = false, features = ["random"]
 fuel-tx = { path = ".", features = ["builder", "random"] }
 fuel-tx-test-helpers = { path = "test-helpers" }
 fuel-types = { version = "0.5", default-features = false, features = ["random"] }
+insta = "1.0"
+proptest = "1.0"
 rand = { version = "0.8", default-features = false, features = ["std_rng"] }
+rstest = "0.13"
 
 [features]
 default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle?/default", "fuel-types/default", "std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,3 +38,6 @@ pub use transaction::{
     Input, Metadata, Output, StorageSlot, Transaction, TransactionRepr, TxId, UtxoId,
     ValidationError, Witness,
 };
+
+#[cfg(feature = "alloc")]
+pub use contract::Contract;

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-1.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-1.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0x9842f250679a7d97dee3f5efaf9d38c1dea17d83ddeab8e4cbbe8eefb9926791

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-10.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-10.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0xdfd9ba908fe30fa53247b1b8c4a37b02a62e8470c24b9d8bf2e01e91dd21edb9

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-100.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-100.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0x2e98c3969a9dd6195000957d4c63f719bb1c456ead6a10c812f3db225ee8a290

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-2.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-2.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0x40aed3f1d3b45d48d3895f7ecd8b4dee2452e41ecb104a31e98dec20081f726f

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-3.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-3.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0x8c02461a4b9aee7faf2e8244ddd0bb9ad8e30bf4e16528d7dcaa8ec991f0cb18

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-4.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-4.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0x8f2e2a02e895166cacd261c55cede7c57a9174aa3f7d006ec548f0bac9e83048

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-5.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-5.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0x72f7ae5aab24e266bd35ae505309d55569bae110f9383b4bada38b134bf6acb2

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-6.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-6.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0xc2f498aa34efbc1a3628564d3d5fd462d27837253fe77b94ac188f0156b41e87

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-7.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-7.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0xff904a16917de130c801eef68dd89509beed5a3a06e8e81f9be5837a33b4d860

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-8.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-8.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0x7bf45deb56341e3a7c6904a756724a1b1d6fc23c963c688536d382db01734498

--- a/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-9.snap
+++ b/src/snapshots/fuel_tx__contract__tests__code_root_snapshot@instructions-9.snap
@@ -1,0 +1,5 @@
+---
+source: src/contract.rs
+expression: root
+---
+0xb2728a5291dc67b0bc8299a2268f8f6197d7fcc9dceead7c27916102f519f718

--- a/src/snapshots/fuel_tx__contract__tests__default_state_root_snapshot.snap
+++ b/src/snapshots/fuel_tx__contract__tests__default_state_root_snapshot.snap
@@ -1,0 +1,6 @@
+---
+source: src/contract.rs
+assertion_line: 223
+expression: default_root
+---
+0x0000000000000000000000000000000000000000000000000000000000000000

--- a/src/snapshots/fuel_tx__contract__tests__state_root_snapshot@state-root-0.snap
+++ b/src/snapshots/fuel_tx__contract__tests__state_root_snapshot@state-root-0.snap
@@ -1,0 +1,6 @@
+---
+source: src/contract.rs
+assertion_line: 217
+expression: state_root
+---
+0x0000000000000000000000000000000000000000000000000000000000000000

--- a/src/snapshots/fuel_tx__contract__tests__state_root_snapshot@state-root-1.snap
+++ b/src/snapshots/fuel_tx__contract__tests__state_root_snapshot@state-root-1.snap
@@ -1,0 +1,6 @@
+---
+source: src/contract.rs
+assertion_line: 217
+expression: state_root
+---
+0x4f4ff4245914fd8fea52ad03b76d88853bb188ae4817bb31c8d56be4ef1910d1

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -192,6 +192,21 @@ impl Transaction {
             .unique()
     }
 
+    #[cfg(feature = "std")]
+    pub fn check_predicate_owners(&self) -> bool {
+        self.inputs()
+            .iter()
+            .filter_map(|i| match i {
+                Input::CoinPredicate {
+                    owner, predicate, ..
+                } => Some((owner, predicate)),
+                _ => None,
+            })
+            .fold(true, |result, (owner, predicate)| {
+                result && Input::is_predicate_owner_valid(owner, predicate)
+            })
+    }
+
     pub const fn gas_price(&self) -> Word {
         match self {
             Self::Script { gas_price, .. } => *gas_price,

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -207,6 +207,15 @@ impl Transaction {
             })
     }
 
+    #[cfg(feature = "std")]
+    pub fn check_predicate_owner(&self, idx: usize) -> bool {
+        matches!(self.inputs().get(idx),
+        Some(Input::CoinPredicate {
+                            owner, predicate, ..
+                        }) if Input::is_predicate_owner_valid(owner, predicate)
+                )
+    }
+
     pub const fn gas_price(&self) -> Word {
         match self {
             Self::Script { gas_price, .. } => *gas_price,

--- a/src/transaction/metadata.rs
+++ b/src/transaction/metadata.rs
@@ -13,7 +13,7 @@ use alloc::vec::Vec;
 pub struct Metadata {
     id: Bytes32,
     script_data_offset: Option<usize>,
-    input_coin_predicate_offset: Vec<Option<usize>>,
+    input_coin_predicate_offset: Vec<Option<(usize, usize)>>,
     inputs_offset: Vec<usize>,
     outputs_offset: Vec<usize>,
     witnesses_offset: Vec<usize>,
@@ -23,7 +23,7 @@ impl Metadata {
     pub const fn new(
         id: Bytes32,
         script_data_offset: Option<usize>,
-        input_coin_predicate_offset: Vec<Option<usize>>,
+        input_coin_predicate_offset: Vec<Option<(usize, usize)>>,
         inputs_offset: Vec<usize>,
         outputs_offset: Vec<usize>,
         witnesses_offset: Vec<usize>,
@@ -46,7 +46,7 @@ impl Metadata {
         self.script_data_offset
     }
 
-    pub fn input_coin_predicate_offset(&self, index: usize) -> Option<usize> {
+    pub fn input_coin_predicate_offset(&self, index: usize) -> Option<(usize, usize)> {
         self.input_coin_predicate_offset
             .get(index)
             .copied()

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -240,13 +240,24 @@ impl Input {
     }
 
     #[cfg(feature = "std")]
-    pub fn is_predicate_owner_valid(owner: &Address, predicate: &[u8]) -> bool {
+    pub fn predicate_owner<P>(predicate: P) -> Address
+    where
+        P: AsRef<[u8]>,
+    {
         use crate::Contract;
 
         // TODO use as no-std as soon as a no-std merkle backend is available
         let root = Contract::root_from_code(predicate);
 
-        owner.as_ref() == root.as_ref()
+        (*root).into()
+    }
+
+    #[cfg(feature = "std")]
+    pub fn is_predicate_owner_valid<P>(owner: &Address, predicate: P) -> bool
+    where
+        P: AsRef<[u8]>,
+    {
+        owner == &Self::predicate_owner(predicate)
     }
 }
 

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -230,6 +230,16 @@ impl Input {
             _ => None,
         }
     }
+
+    #[cfg(feature = "std")]
+    pub fn is_predicate_owner_valid(owner: &Address, predicate: &[u8]) -> bool {
+        use crate::Contract;
+
+        // TODO use as no-std as soon as a no-std merkle backend is available
+        let root = Contract::root_from_code(predicate);
+
+        owner.as_ref() == root.as_ref()
+    }
 }
 
 #[cfg(feature = "std")]

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -221,6 +221,14 @@ impl Input {
         INPUT_COIN_FIXED_SIZE
     }
 
+    pub fn coin_predicate_len(&self) -> Option<usize> {
+        match self {
+            Input::CoinPredicate { predicate, .. } => Some(bytes::padded_len(predicate.as_slice())),
+
+            _ => None,
+        }
+    }
+
     pub fn coin_predicate_data_offset(&self) -> Option<usize> {
         match self {
             Input::CoinPredicate { predicate, .. } => {

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -723,19 +723,16 @@ fn create_input_coin_data_offset() {
                             .read(buffer.as_mut_slice())
                             .expect("Failed to serialize input");
 
-                        let offset = tx
+                        let (offset, len) = tx
                             .input_coin_predicate_offset(last_input)
                             .expect("Failed to fetch offset");
 
-                        let offset_p = tx_p
+                        let (offset_p, _) = tx_p
                             .input_coin_predicate_offset(last_input)
                             .expect("Failed to fetch offset from tx with precomputed metadata!");
 
                         assert_eq!(offset, offset_p);
-                        assert_eq!(
-                            predicate.as_slice(),
-                            &buffer[offset..offset + predicate.len()]
-                        );
+                        assert_eq!(predicate.as_slice(), &buffer[offset..offset + len]);
                     }
                 }
             }
@@ -777,7 +774,13 @@ fn script_input_coin_data_offset() {
         vec![generate_bytes(rng).into(), generate_bytes(rng).into()],
     ];
 
-    let predicate = generate_nonempty_bytes(rng);
+    let mut predicate = generate_nonempty_bytes(rng);
+
+    // force word-unaligned predicate
+    if predicate.len() % 2 == 0 {
+        predicate.push(0xff);
+    }
+
     let predicate_data = generate_bytes(rng);
 
     let owner = (*Contract::root_from_code(&predicate)).into();
@@ -843,9 +846,13 @@ fn script_input_coin_data_offset() {
                             &buffer[script_data_offset..script_data_offset + script_data.len()]
                         );
 
-                        let offset = tx
+                        let (offset, len) = tx
                             .input_coin_predicate_offset(offset)
                             .expect("Failed to fetch offset");
+
+                        assert_ne!(predicate.len(), len);
+                        assert_eq!(bytes::padded_len(&predicate), len);
+
                         assert_eq!(
                             predicate.as_slice(),
                             &buffer[offset..offset + predicate.len()]

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,5 +1,4 @@
 use fuel_asm::Opcode;
-use fuel_crypto::Hasher;
 use fuel_tx::consts::MAX_GAS_PER_TX;
 use fuel_tx::*;
 use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
@@ -680,7 +679,7 @@ fn create_input_coin_data_offset() {
     let predicate = generate_nonempty_bytes(rng);
     let predicate_data = generate_bytes(rng);
 
-    let owner = (*Hasher::hash(predicate.as_slice())).into();
+    let owner = (*Contract::root_from_code(&predicate)).into();
 
     let input_coin = Input::coin_predicate(
         rng.gen(),
@@ -781,7 +780,7 @@ fn script_input_coin_data_offset() {
     let predicate = generate_nonempty_bytes(rng);
     let predicate_data = generate_bytes(rng);
 
-    let owner = (*Hasher::hash(predicate.as_slice())).into();
+    let owner = (*Contract::root_from_code(&predicate)).into();
 
     let input_coin = Input::coin_predicate(
         rng.gen(),

--- a/tests/valid_cases/input.rs
+++ b/tests/valid_cases/input.rs
@@ -1,4 +1,4 @@
-use fuel_crypto::{Hasher, SecretKey};
+use fuel_crypto::SecretKey;
 use fuel_tx::*;
 use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes, TransactionFactory};
 use rand::rngs::StdRng;
@@ -91,7 +91,7 @@ fn coin_predicate() {
     let txhash: Bytes32 = rng.gen();
 
     let predicate = generate_nonempty_bytes(rng);
-    let owner = (*Hasher::hash(predicate.as_slice())).into();
+    let owner = (*Contract::root_from_code(&predicate)).into();
 
     Input::coin_predicate(
         rng.gen(),
@@ -106,7 +106,7 @@ fn coin_predicate() {
     .unwrap();
 
     let predicate = vec![];
-    let owner = (*Hasher::hash(predicate.as_slice())).into();
+    let owner = (*Contract::root_from_code(&predicate)).into();
 
     let err = Input::coin_predicate(
         rng.gen(),
@@ -124,7 +124,7 @@ fn coin_predicate() {
     assert_eq!(ValidationError::InputCoinPredicateLength { index: 1 }, err);
 
     let mut predicate = generate_nonempty_bytes(rng);
-    let owner = (*Hasher::hash(predicate.as_slice())).into();
+    let owner = (*Contract::root_from_code(&predicate)).into();
     predicate[0] = predicate[0].wrapping_add(1);
 
     let err = Input::coin_predicate(


### PR DESCRIPTION
A sparse merkle tree is used to calculate the initial state root of a
contract.

It is done so due to the mutable nature of the state.