### PR TITLE
Refactor most constants as configurable parameters

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -1,43 +1,6 @@
 use fuel_types::bytes::WORD_SIZE;
 use fuel_types::{Bytes32, Salt};
 
-/// Maximum contract size, in bytes.
-pub const CONTRACT_MAX_SIZE: u64 = 16 * 1024 * 1024;
-
-/// Maximum number of inputs.
-pub const MAX_INPUTS: u8 = 255;
-
-/// Maximum number of outputs.
-pub const MAX_OUTPUTS: u8 = 255;
-
-/// Maximum number of witnesses.
-pub const MAX_WITNESSES: u8 = 255;
-
-/// Maximum gas per transaction.
-pub const MAX_GAS_PER_TX: u64 = 100_000_000;
-
-// TODO set max script length const
-/// Maximum length of script, in instructions.
-pub const MAX_SCRIPT_LENGTH: u64 = 1024 * 1024;
-
-// TODO set max script length const
-/// Maximum length of script data, in bytes.
-pub const MAX_SCRIPT_DATA_LENGTH: u64 = 1024 * 1024;
-
-/// Maximum number of static contracts.
-pub const MAX_STATIC_CONTRACTS: u64 = 255;
-
-/// Maximum number of initial storage slots.
-pub const MAX_STORAGE_SLOTS: u16 = 255;
-
-// TODO set max predicate length value
-/// Maximum length of predicate, in instructions.
-pub const MAX_PREDICATE_LENGTH: u64 = 1024 * 1024;
-
-// TODO set max predicate data length value
-/// Maximum length of predicate data, in bytes.
-pub const MAX_PREDICATE_DATA_LENGTH: u64 = 1024 * 1024;
-
 pub const TRANSACTION_SCRIPT_FIXED_SIZE: usize = WORD_SIZE // Identifier
     + WORD_SIZE // Gas price
     + WORD_SIZE // Gas limit

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,6 @@ pub use receipt::{Receipt, ScriptExecutionResult};
 
 #[cfg(feature = "alloc")]
 pub use transaction::{
-    Input, Metadata, Output, StorageSlot, Transaction, TransactionRepr, TxId, UtxoId,
-    ValidationError, Witness,
+    consensus_parameters::*, Input, Metadata, Output, StorageSlot, Transaction, TransactionRepr,
+    TxId, UtxoId, ValidationError, Witness,
 };

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -25,6 +25,8 @@ mod id;
 #[cfg(feature = "std")]
 mod txio;
 
+pub mod consensus_parameters;
+
 pub use metadata::Metadata;
 pub use repr::TransactionRepr;
 pub use types::{Input, Output, StorageSlot, UtxoId, Witness};
@@ -76,17 +78,7 @@ impl Default for Transaction {
         // The Return op is mandatory for the execution of any context
         let script = Opcode::RET(0x10).to_bytes().to_vec();
 
-        Transaction::script(
-            0,
-            MAX_GAS_PER_TX,
-            0,
-            0,
-            script,
-            vec![],
-            vec![],
-            vec![],
-            vec![],
-        )
+        Transaction::script(0, 1, 0, 0, script, vec![], vec![], vec![], vec![])
     }
 }
 

--- a/src/transaction/consensus_parameters.rs
+++ b/src/transaction/consensus_parameters.rs
@@ -6,11 +6,11 @@ pub struct ConsensusParameters {
     /// Maximum contract size, in bytes.
     pub contract_max_size: u64,
     /// Maximum number of inputs.
-    pub max_inputs: u8,
+    pub max_inputs: u64,
     /// Maximum number of outputs.
-    pub max_outputs: u8,
+    pub max_outputs: u64,
     /// Maximum number of witnesses.
-    pub max_witnesses: u8,
+    pub max_witnesses: u64,
     /// Maximum gas per transaction.
     pub max_gas_per_tx: u64,
     /// Maximum length of script, in instructions.
@@ -50,9 +50,9 @@ impl Default for ConsensusParameters {
 /// reasonable settings, they may not be useful for every network instantiation.
 pub mod default_parameters {
     pub const CONTRACT_MAX_SIZE: u64 = 16 * 1024 * 1024;
-    pub const MAX_INPUTS: u8 = 255;
-    pub const MAX_OUTPUTS: u8 = 255;
-    pub const MAX_WITNESSES: u8 = 255;
+    pub const MAX_INPUTS: u64 = 255;
+    pub const MAX_OUTPUTS: u64 = 255;
+    pub const MAX_WITNESSES: u64 = 255;
     pub const MAX_GAS_PER_TX: u64 = 100_000_000;
     pub const MAX_SCRIPT_LENGTH: u64 = 1024 * 1024;
     pub const MAX_SCRIPT_DATA_LENGTH: u64 = 1024 * 1024;

--- a/src/transaction/consensus_parameters.rs
+++ b/src/transaction/consensus_parameters.rs
@@ -1,0 +1,63 @@
+/// Consensus configurable parameters used for verifying transactions
+
+#[derive(Copy, Clone, Debug, PartialEq, Hash)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+pub struct ConsensusParameters {
+    /// Maximum contract size, in bytes.
+    pub contract_max_size: u64,
+    /// Maximum number of inputs.
+    pub max_inputs: u8,
+    /// Maximum number of outputs.
+    pub max_outputs: u8,
+    /// Maximum number of witnesses.
+    pub max_witnesses: u8,
+    /// Maximum gas per transaction.
+    pub max_gas_per_tx: u64,
+    /// Maximum length of script, in instructions.
+    pub max_script_length: u64,
+    /// Maximum length of script data, in bytes.
+    pub max_script_data_length: u64,
+    /// Maximum number of static contracts.
+    pub max_static_contracts: u64,
+    /// Maximum number of initial storage slots.
+    pub max_storage_slots: u64,
+    /// Maximum length of predicate, in instructions.
+    pub max_predicate_length: u64,
+    /// Maximum length of predicate data, in bytes.
+    pub max_predicate_data_length: u64,
+}
+
+impl Default for ConsensusParameters {
+    fn default() -> Self {
+        use default_parameters::*;
+        Self {
+            contract_max_size: CONTRACT_MAX_SIZE,
+            max_inputs: MAX_INPUTS,
+            max_outputs: MAX_OUTPUTS,
+            max_witnesses: MAX_WITNESSES,
+            max_gas_per_tx: MAX_GAS_PER_TX,
+            max_script_length: MAX_SCRIPT_LENGTH,
+            max_script_data_length: MAX_SCRIPT_DATA_LENGTH,
+            max_static_contracts: MAX_STATIC_CONTRACTS,
+            max_storage_slots: MAX_STORAGE_SLOTS,
+            max_predicate_length: MAX_PREDICATE_LENGTH,
+            max_predicate_data_length: MAX_PREDICATE_DATA_LENGTH,
+        }
+    }
+}
+
+/// Arbitrary default consensus parameters. While best-efforts are made to adjust these to
+/// reasonable settings, they may not be useful for every network instantiation.
+pub mod default_parameters {
+    pub const CONTRACT_MAX_SIZE: u64 = 16 * 1024 * 1024;
+    pub const MAX_INPUTS: u8 = 255;
+    pub const MAX_OUTPUTS: u8 = 255;
+    pub const MAX_WITNESSES: u8 = 255;
+    pub const MAX_GAS_PER_TX: u64 = 100_000_000;
+    pub const MAX_SCRIPT_LENGTH: u64 = 1024 * 1024;
+    pub const MAX_SCRIPT_DATA_LENGTH: u64 = 1024 * 1024;
+    pub const MAX_STATIC_CONTRACTS: u64 = 255;
+    pub const MAX_STORAGE_SLOTS: u64 = 255;
+    pub const MAX_PREDICATE_LENGTH: u64 = 1024 * 1024;
+    pub const MAX_PREDICATE_DATA_LENGTH: u64 = 1024 * 1024;
+}

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -104,7 +104,7 @@ impl Transaction {
 
 #[cfg(all(test, feature = "random"))]
 mod tests {
-    use crate::consts::MAX_GAS_PER_TX;
+    use crate::default_parameters::MAX_GAS_PER_TX;
     use crate::*;
 
     use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,7 +1,6 @@
 use fuel_asm::Opcode;
 use fuel_crypto::Hasher;
-use fuel_tx::consts::MAX_GAS_PER_TX;
-use fuel_tx::*;
+use fuel_tx::{default_parameters::*, *};
 use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
 use fuel_types::{bytes, ContractId, Immediate24};
 use rand::rngs::StdRng;

--- a/tests/valid_cases/input.rs
+++ b/tests/valid_cases/input.rs
@@ -20,7 +20,9 @@ fn coin_signed() {
             .iter()
             .enumerate()
             .try_for_each(|(index, input)| match input {
-                Input::CoinSigned { .. } => input.validate(index, &txhash, outputs, witnesses),
+                Input::CoinSigned { .. } => {
+                    input.validate(index, &txhash, outputs, witnesses, &Default::default())
+                }
                 _ => Ok(()),
             })
     }
@@ -76,7 +78,10 @@ fn coin_signed() {
     tx.add_input(input);
 
     let block_height = rng.gen();
-    let err = tx.validate(block_height).err().expect("Expected failure");
+    let err = tx
+        .validate(block_height, &Default::default())
+        .err()
+        .expect("Expected failure");
 
     assert!(matches!(
         err,
@@ -102,7 +107,7 @@ fn coin_predicate() {
         predicate,
         generate_bytes(rng),
     )
-    .validate(1, &txhash, &[], &[])
+    .validate(1, &txhash, &[], &[], &Default::default())
     .unwrap();
 
     let predicate = vec![];
@@ -117,7 +122,7 @@ fn coin_predicate() {
         predicate,
         generate_bytes(rng),
     )
-    .validate(1, &txhash, &[], &[])
+    .validate(1, &txhash, &[], &[], &Default::default())
     .err()
     .unwrap();
 
@@ -136,7 +141,7 @@ fn coin_predicate() {
         predicate,
         generate_bytes(rng),
     )
-    .validate(1, &txhash, &[], &[])
+    .validate(1, &txhash, &[], &[], &Default::default())
     .err()
     .unwrap();
 
@@ -155,11 +160,12 @@ fn contract() {
             &txhash,
             &[Output::contract(1, rng.gen(), rng.gen())],
             &[],
+            &Default::default(),
         )
         .unwrap();
 
     let err = Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen())
-        .validate(1, &txhash, &[], &[])
+        .validate(1, &txhash, &[], &[], &Default::default())
         .err()
         .unwrap();
     assert_eq!(
@@ -173,6 +179,7 @@ fn contract() {
             &txhash,
             &[Output::coin(rng.gen(), rng.gen(), rng.gen())],
             &[],
+            &Default::default(),
         )
         .err()
         .unwrap();
@@ -187,6 +194,7 @@ fn contract() {
             &txhash,
             &[Output::contract(2, rng.gen(), rng.gen())],
             &[],
+            &Default::default(),
         )
         .err()
         .unwrap();
@@ -209,7 +217,7 @@ fn transaction_with_duplicate_coin_inputs_is_invalid() {
         .add_input(b)
         .add_witness(rng.gen())
         .finalize()
-        .validate_without_signature(0)
+        .validate_without_signature(0, &Default::default())
         .err()
         .expect("Expected validation failure");
 
@@ -233,7 +241,7 @@ fn transaction_with_duplicate_contract_inputs_is_invalid() {
         .add_output(o)
         .add_output(p)
         .finalize()
-        .validate_without_signature(0)
+        .validate_without_signature(0, &Default::default())
         .err()
         .expect("Expected validation failure");
 
@@ -260,6 +268,6 @@ fn transaction_with_duplicate_contract_utxo_id_is_valid() {
         .add_output(o)
         .add_output(p)
         .finalize()
-        .validate_without_signature(0)
+        .validate_without_signature(0, &Default::default())
         .expect("Duplicated UTXO id is valid for contract input");
 }

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -1,12 +1,35 @@
+use default_parameters::{
+    CONTRACT_MAX_SIZE, MAX_GAS_PER_TX, MAX_PREDICATE_DATA_LENGTH, MAX_PREDICATE_LENGTH,
+};
 use fuel_crypto::SecretKey;
-use fuel_tx::consts::*;
 use fuel_tx::*;
 use fuel_tx_test_helpers::generate_bytes;
-use rand::rngs::StdRng;
-use rand::{Rng, RngCore, SeedableRng};
+use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+use std::{cmp, io::Write};
 
-use std::cmp;
-use std::io::Write;
+// override default settings to reduce testing overhead
+pub const MAX_STORAGE_SLOTS: u64 = 1024;
+pub const MAX_SCRIPT_LENGTH: u64 = 1024;
+pub const MAX_SCRIPT_DATA_LENGTH: u64 = 1024;
+pub const MAX_STATIC_CONTRACTS: u64 = 16;
+pub const MAX_INPUTS: u8 = 16;
+pub const MAX_OUTPUTS: u8 = 16;
+pub const MAX_WITNESSES: u8 = 16;
+
+// Setup custom consensus params struct for testing
+pub const CONSENSUS_PARAMS: ConsensusParameters = ConsensusParameters {
+    contract_max_size: CONTRACT_MAX_SIZE,
+    max_inputs: MAX_INPUTS,
+    max_outputs: MAX_OUTPUTS,
+    max_witnesses: MAX_WITNESSES,
+    max_gas_per_tx: MAX_GAS_PER_TX,
+    max_script_length: MAX_SCRIPT_LENGTH,
+    max_script_data_length: MAX_SCRIPT_DATA_LENGTH,
+    max_static_contracts: MAX_STATIC_CONTRACTS,
+    max_storage_slots: MAX_STORAGE_SLOTS,
+    max_predicate_length: MAX_PREDICATE_LENGTH,
+    max_predicate_data_length: MAX_PREDICATE_DATA_LENGTH,
+};
 
 #[test]
 fn gas_limit() {
@@ -26,7 +49,7 @@ fn gas_limit() {
         vec![],
         vec![],
     )
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .expect("Failed to validate transaction");
 
     Transaction::create(
@@ -42,7 +65,7 @@ fn gas_limit() {
         vec![],
         vec![vec![0xfau8].into()],
     )
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .expect("Failed to validate transaction");
 
     let err = Transaction::script(
@@ -56,7 +79,7 @@ fn gas_limit() {
         vec![],
         vec![],
     )
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -75,7 +98,7 @@ fn gas_limit() {
         vec![],
         vec![generate_bytes(rng).into()],
     )
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -99,7 +122,7 @@ fn maturity() {
         vec![],
         vec![],
     )
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .expect("Failed to validate script");
 
     Transaction::create(
@@ -115,7 +138,7 @@ fn maturity() {
         vec![],
         vec![rng.gen()],
     )
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .expect("Failed to validate tx create");
 
     let err = Transaction::script(
@@ -129,7 +152,7 @@ fn maturity() {
         vec![],
         vec![],
     )
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -148,7 +171,7 @@ fn maturity() {
         vec![],
         vec![rng.gen()],
     )
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -184,7 +207,7 @@ fn max_iow() {
 
     builder
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .expect("Failed to validate transaction");
 
     // Add inputs up to maximum and validate
@@ -216,7 +239,7 @@ fn max_iow() {
 
     builder
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .expect("Failed to validate transaction");
 
     // Overflow maximum inputs and expect error
@@ -246,7 +269,7 @@ fn max_iow() {
 
     let err = builder
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -279,7 +302,7 @@ fn max_iow() {
 
     let err = builder
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -312,7 +335,7 @@ fn max_iow() {
 
     let err = builder
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -341,7 +364,7 @@ fn output_change_asset_id() {
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), b))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .expect("Failed to validate transaction");
 
     let err = TransactionBuilder::script(generate_bytes(rng), generate_bytes(rng))
@@ -353,7 +376,7 @@ fn output_change_asset_id() {
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -371,7 +394,7 @@ fn output_change_asset_id() {
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .add_output(Output::change(rng.gen(), rng.next_u64(), c))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -389,7 +412,7 @@ fn output_change_asset_id() {
         .add_output(Output::coin(rng.gen(), rng.next_u64(), a))
         .add_output(Output::coin(rng.gen(), rng.next_u64(), c))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -419,7 +442,7 @@ fn script() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .expect("Failed to validate transaction");
 
     let err = TransactionBuilder::script(
@@ -432,7 +455,7 @@ fn script() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -451,7 +474,7 @@ fn script() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -467,7 +490,7 @@ fn script() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), asset_id, rng.gen())
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -490,7 +513,7 @@ fn create() {
         .maturity(maturity)
         .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), rng.gen(), maturity)
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .expect("Failed to validate tx");
 
     let err = TransactionBuilder::create(generate_bytes(rng).into(), rng.gen(), vec![], vec![])
@@ -500,7 +523,7 @@ fn create() {
         .add_input(Input::contract(rng.gen(), rng.gen(), rng.gen(), rng.gen()))
         .add_output(Output::contract(0, rng.gen(), rng.gen()))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -516,7 +539,7 @@ fn create() {
         .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), rng.gen(), maturity)
         .add_output(Output::variable(rng.gen(), rng.gen(), rng.gen()))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -534,7 +557,7 @@ fn create() {
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -554,7 +577,7 @@ fn create() {
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -572,7 +595,7 @@ fn create() {
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .finalize()
-        .validate(block_height)
+        .validate(block_height, &CONSENSUS_PARAMS)
         .err()
         .expect("Expected erroneous transaction");
 
@@ -593,7 +616,7 @@ fn create() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .expect("Failed to validate the transaction");
 
     let err = TransactionBuilder::create(
@@ -608,7 +631,7 @@ fn create() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -627,7 +650,7 @@ fn create() {
         vec![],
         vec![],
     )
-    .validate_without_signature(block_height)
+    .validate_without_signature(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -655,7 +678,7 @@ fn create() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .expect("Failed to validate the transaction");
 
     let mut contracts_overflow = static_contracts.clone();
@@ -676,7 +699,7 @@ fn create() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -698,7 +721,7 @@ fn create() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -728,7 +751,7 @@ fn create() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .expect("Failed to validate the transaction");
 
     // Test max slots can't be exceeded
@@ -749,7 +772,7 @@ fn create() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 
@@ -772,7 +795,7 @@ fn create() {
     .add_unsigned_coin_input(rng.gen(), &secret, rng.gen(), AssetId::default(), maturity)
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
-    .validate(block_height)
+    .validate(block_height, &CONSENSUS_PARAMS)
     .err()
     .expect("Expected erroneous transaction");
 

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -12,9 +12,9 @@ pub const MAX_STORAGE_SLOTS: u64 = 1024;
 pub const MAX_SCRIPT_LENGTH: u64 = 1024;
 pub const MAX_SCRIPT_DATA_LENGTH: u64 = 1024;
 pub const MAX_STATIC_CONTRACTS: u64 = 16;
-pub const MAX_INPUTS: u8 = 16;
-pub const MAX_OUTPUTS: u8 = 16;
-pub const MAX_WITNESSES: u8 = 16;
+pub const MAX_INPUTS: u64 = 16;
+pub const MAX_OUTPUTS: u64 = 16;
+pub const MAX_WITNESSES: u64 = 16;
 
 // Setup custom consensus params struct for testing
 pub const CONSENSUS_PARAMS: ConsensusParameters = ConsensusParameters {


### PR DESCRIPTION
What?

This PR converts constants used for validating transactions into configurable parameters.

Why?

Making the parameters used for transaction validation compile time constants was overly cumbersome. We're still in the early stages and fine-tuning many of these parameters, so we need to be able to set these validation parameters at runtime rather than requiring new releases of fuel-tx (and docker image of fuel-core) every time a setting is tweaked. Moreover, each fuel-network instantiation may have different requirements.

fixes #114 

