### PR TITLE
fix transaction::default gas limit

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -78,7 +78,18 @@ impl Default for Transaction {
         // The Return op is mandatory for the execution of any context
         let script = Opcode::RET(0x10).to_bytes().to_vec();
 
-        Transaction::script(0, 1, 0, 0, script, vec![], vec![], vec![], vec![])
+        Transaction::script(
+            0,
+            // use default max gas per tx
+            consensus_parameters::default_parameters::MAX_GAS_PER_TX,
+            0,
+            0,
+            script,
+            vec![],
+            vec![],
+            vec![],
+            vec![],
+        )
     }
 }
 


### PR DESCRIPTION
the gas limit was way too low as @leviathanbeak pointed out in #130 and this broke some tests in the VM. Setting to the consensus default