### PR TITLE
Add `Transaction::receipts_root_offset`

### DIFF
--- a/src/transaction/offset.rs
+++ b/src/transaction/offset.rs
@@ -2,7 +2,7 @@ use super::{TRANSACTION_CREATE_FIXED_SIZE, TRANSACTION_SCRIPT_FIXED_SIZE};
 use crate::{Input, Metadata, StorageSlot, Transaction};
 
 use fuel_types::bytes::{self, SizedBytes};
-use fuel_types::ContractId;
+use fuel_types::{Bytes32, ContractId};
 
 impl Transaction {
     /// For a serialized transaction of type `Script`, return the bytes offset
@@ -194,5 +194,14 @@ impl Transaction {
                 .sum::<usize>()
                 + offset
         })
+    }
+
+    /// For a serialized transaction of type `Script`, return the bytes offset
+    /// of the receipts root
+    pub const fn receipts_root_offset(&self) -> Option<usize> {
+        match self {
+            Self::Script { .. } => Some(TRANSACTION_SCRIPT_FIXED_SIZE - Bytes32::LEN),
+            Self::Create { .. } => None,
+        }
     }
 }

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,5 +1,4 @@
 use fuel_asm::Opcode;
-use fuel_crypto::Hasher;
 use fuel_tx::{default_parameters::*, *};
 use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
 use fuel_types::{bytes, ContractId, Immediate24};

--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -1,9 +1,12 @@
 use fuel_tx::*;
 use fuel_tx_test_helpers::TransactionFactory;
 use fuel_types::bytes::{Deserializable, SerializableVec};
+use rand::{rngs::StdRng, Rng, SeedableRng};
 
 #[test]
 fn iow_offset() {
+    let rng = &mut StdRng::seed_from_u64(8586);
+
     TransactionFactory::from_seed(3493)
         .take(100)
         .for_each(|(mut tx, _)| {
@@ -43,6 +46,17 @@ fn iow_offset() {
 
                 assert_eq!(w, &witness);
                 assert_eq!(offset, offset_p);
+            });
+
+            tx.receipts_root_offset().map(|offset| {
+                let receipts_root = rng.gen();
+
+                tx.set_receipts_root(receipts_root);
+
+                let bytes = tx.to_bytes();
+                let receipts_root_p = &bytes[offset..offset + Bytes32::LEN];
+
+                assert_eq!(&receipts_root[..], receipts_root_p);
             });
         });
 }


### PR DESCRIPTION
The receipts root will be updated at runtime in the vm. Hence, its
offset must be known for script transactions.

This function is checking for the correct variant of
`Transaction::Script` so it won't be misused for transactions that
doesn't contain receipts root offsets.