### PR TITLE
Add gas price factor consensus parameter

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,4 +1,5 @@
 use crate::consts::*;
+use crate::ConsensusParameters;
 
 use fuel_asm::Opcode;
 use fuel_types::{AssetId, Bytes32, ContractId, Salt, Word};
@@ -80,8 +81,7 @@ impl Default for Transaction {
 
         Transaction::script(
             0,
-            // use default max gas per tx
-            consensus_parameters::default_parameters::MAX_GAS_PER_TX,
+            ConsensusParameters::DEFAULT.max_gas_per_tx,
             0,
             0,
             script,

--- a/src/transaction/consensus_parameters.rs
+++ b/src/transaction/consensus_parameters.rs
@@ -1,5 +1,4 @@
 /// Consensus configurable parameters used for verifying transactions
-
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ConsensusParameters {
@@ -25,39 +24,447 @@ pub struct ConsensusParameters {
     pub max_predicate_length: u64,
     /// Maximum length of predicate data, in bytes.
     pub max_predicate_data_length: u64,
+    /// Factor to convert between gas and transaction assets value.
+    pub gas_price_factor: u64,
+}
+
+impl ConsensusParameters {
+    /// Default consensus parameters with settings suggested in fuel-specs
+    pub const DEFAULT: Self = Self {
+        contract_max_size: 16 * 1024 * 1024,
+        max_inputs: 255,
+        max_outputs: 255,
+        max_witnesses: 255,
+        max_gas_per_tx: 100_000_000,
+        max_script_length: 1024 * 1024,
+        max_script_data_length: 1024 * 1024,
+        max_static_contracts: 255,
+        max_storage_slots: 255,
+        max_predicate_length: 1024 * 1024,
+        max_predicate_data_length: 1024 * 1024,
+        gas_price_factor: 1_000_000_000,
+    };
+
+    /// Replace the max contract size with the given argument
+    pub const fn with_contract_max_size(self, contract_max_size: u64) -> Self {
+        let Self {
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max inputs with the given argument
+    pub const fn with_max_inputs(self, max_inputs: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max outputs with the given argument
+    pub const fn with_max_outputs(self, max_outputs: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max witnesses with the given argument
+    pub const fn with_max_witnesses(self, max_witnesses: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max gas per transaction with the given argument
+    pub const fn with_max_gas_per_tx(self, max_gas_per_tx: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max script length with the given argument
+    pub const fn with_max_script_length(self, max_script_length: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max script data length with the given argument
+    pub const fn with_max_script_data_length(self, max_script_data_length: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max static contracts with the given argument
+    pub const fn with_max_static_contracts(self, max_static_contracts: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max storage slots with the given argument
+    pub const fn with_max_storage_slots(self, max_storage_slots: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max predicate length with the given argument
+    pub const fn with_max_predicate_length(self, max_predicate_length: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_data_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the max predicate data length with the given argument
+    pub const fn with_max_predicate_data_length(self, max_predicate_data_length: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            gas_price_factor,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
+
+    /// Replace the gas price factor with the given argument
+    pub const fn with_gas_price_factor(self, gas_price_factor: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_static_contracts,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+        }
+    }
 }
 
 impl Default for ConsensusParameters {
     fn default() -> Self {
-        use default_parameters::*;
-        Self {
-            contract_max_size: CONTRACT_MAX_SIZE,
-            max_inputs: MAX_INPUTS,
-            max_outputs: MAX_OUTPUTS,
-            max_witnesses: MAX_WITNESSES,
-            max_gas_per_tx: MAX_GAS_PER_TX,
-            max_script_length: MAX_SCRIPT_LENGTH,
-            max_script_data_length: MAX_SCRIPT_DATA_LENGTH,
-            max_static_contracts: MAX_STATIC_CONTRACTS,
-            max_storage_slots: MAX_STORAGE_SLOTS,
-            max_predicate_length: MAX_PREDICATE_LENGTH,
-            max_predicate_data_length: MAX_PREDICATE_DATA_LENGTH,
-        }
+        Self::DEFAULT
     }
 }
 
 /// Arbitrary default consensus parameters. While best-efforts are made to adjust these to
 /// reasonable settings, they may not be useful for every network instantiation.
+#[deprecated(since = "0.12.2", note = "use `ConsensusParameters` instead.")]
 pub mod default_parameters {
-    pub const CONTRACT_MAX_SIZE: u64 = 16 * 1024 * 1024;
-    pub const MAX_INPUTS: u64 = 255;
-    pub const MAX_OUTPUTS: u64 = 255;
-    pub const MAX_WITNESSES: u64 = 255;
-    pub const MAX_GAS_PER_TX: u64 = 100_000_000;
-    pub const MAX_SCRIPT_LENGTH: u64 = 1024 * 1024;
-    pub const MAX_SCRIPT_DATA_LENGTH: u64 = 1024 * 1024;
-    pub const MAX_STATIC_CONTRACTS: u64 = 255;
-    pub const MAX_STORAGE_SLOTS: u64 = 255;
-    pub const MAX_PREDICATE_LENGTH: u64 = 1024 * 1024;
-    pub const MAX_PREDICATE_DATA_LENGTH: u64 = 1024 * 1024;
+    use super::ConsensusParameters;
+
+    pub const CONTRACT_MAX_SIZE: u64 = ConsensusParameters::DEFAULT.contract_max_size;
+    pub const MAX_INPUTS: u64 = ConsensusParameters::DEFAULT.max_inputs;
+    pub const MAX_OUTPUTS: u64 = ConsensusParameters::DEFAULT.max_outputs;
+    pub const MAX_WITNESSES: u64 = ConsensusParameters::DEFAULT.max_witnesses;
+    pub const MAX_GAS_PER_TX: u64 = ConsensusParameters::DEFAULT.max_gas_per_tx;
+    pub const MAX_SCRIPT_LENGTH: u64 = ConsensusParameters::DEFAULT.max_script_length;
+    pub const MAX_SCRIPT_DATA_LENGTH: u64 = ConsensusParameters::DEFAULT.max_script_data_length;
+    pub const MAX_STATIC_CONTRACTS: u64 = ConsensusParameters::DEFAULT.max_static_contracts;
+    pub const MAX_STORAGE_SLOTS: u64 = ConsensusParameters::DEFAULT.max_storage_slots;
+    pub const MAX_PREDICATE_LENGTH: u64 = ConsensusParameters::DEFAULT.max_predicate_length;
+    pub const MAX_PREDICATE_DATA_LENGTH: u64 =
+        ConsensusParameters::DEFAULT.max_predicate_data_length;
+    pub const GAS_PRICE_FACTOR: u64 = ConsensusParameters::DEFAULT.gas_price_factor;
 }

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -104,7 +104,6 @@ impl Transaction {
 
 #[cfg(all(test, feature = "random"))]
 mod tests {
-    use crate::default_parameters::MAX_GAS_PER_TX;
     use crate::*;
 
     use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
@@ -362,7 +361,7 @@ mod tests {
                         for storage_slots in storage_slots.iter() {
                             let tx = Transaction::create(
                                 rng.next_u64(),
-                                MAX_GAS_PER_TX,
+                                ConsensusParameters::DEFAULT.max_gas_per_tx,
                                 rng.next_u64(),
                                 rng.next_u64(),
                                 rng.next_u32().to_be_bytes()[0],

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -1,5 +1,5 @@
 use fuel_asm::Opcode;
-use fuel_tx::{default_parameters::*, *};
+use fuel_tx::*;
 use fuel_tx_test_helpers::{generate_bytes, generate_nonempty_bytes};
 use fuel_types::{bytes, ContractId, Immediate24};
 use rand::rngs::StdRng;
@@ -562,7 +562,7 @@ fn transaction() {
         ),
         Transaction::create(
             rng.next_u64(),
-            MAX_GAS_PER_TX,
+            ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
             rng.next_u64(),
             rng.gen(),
@@ -575,7 +575,7 @@ fn transaction() {
         ),
         Transaction::create(
             rng.next_u64(),
-            MAX_GAS_PER_TX,
+            ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
             rng.next_u64(),
             rng.gen(),
@@ -588,7 +588,7 @@ fn transaction() {
         ),
         Transaction::create(
             rng.next_u64(),
-            MAX_GAS_PER_TX,
+            ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
             rng.next_u64(),
             rng.gen(),
@@ -601,7 +601,7 @@ fn transaction() {
         ),
         Transaction::create(
             rng.next_u64(),
-            MAX_GAS_PER_TX,
+            ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
             rng.next_u64(),
             rng.gen(),
@@ -614,7 +614,7 @@ fn transaction() {
         ),
         Transaction::create(
             rng.next_u64(),
-            MAX_GAS_PER_TX,
+            ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
             rng.next_u64(),
             rng.gen(),
@@ -627,7 +627,7 @@ fn transaction() {
         ),
         Transaction::create(
             rng.next_u64(),
-            MAX_GAS_PER_TX,
+            ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
             rng.next_u64(),
             rng.gen(),


### PR DESCRIPTION
The gas price factor will be used to convert between gas units and the
base asset value of the transaction.

This will empower the users to execute cheap/micro transactions without
being punished with high gas overheads.

Related issue: https://github.com/FuelLabs/fuel-specs/issues/342