### PR TITLE
Add tx memory offset as consensus params function

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,9 +35,13 @@ pub use receipt::{Receipt, ScriptExecutionResult};
 
 #[cfg(feature = "alloc")]
 pub use transaction::{
-    consensus_parameters::*, Input, Metadata, Output, StorageSlot, Transaction, TransactionRepr,
-    TxId, UtxoId, ValidationError, Witness,
+    ConsensusParameters, Input, Metadata, Output, StorageSlot, Transaction, TransactionRepr, TxId,
+    UtxoId, ValidationError, Witness,
 };
+
+#[cfg(feature = "alloc")]
+#[allow(deprecated)]
+pub use transaction::consensus_parameters::default_parameters;
 
 #[cfg(feature = "alloc")]
 pub use contract::Contract;

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,5 +1,4 @@
 use crate::consts::*;
-use crate::ConsensusParameters;
 
 use fuel_asm::Opcode;
 use fuel_types::{AssetId, Bytes32, ContractId, Salt, Word};
@@ -28,6 +27,7 @@ mod txio;
 
 pub mod consensus_parameters;
 
+pub use consensus_parameters::ConsensusParameters;
 pub use metadata::Metadata;
 pub use repr::TransactionRepr;
 pub use types::{Input, Output, StorageSlot, UtxoId, Witness};

--- a/src/transaction/consensus_parameters.rs
+++ b/src/transaction/consensus_parameters.rs
@@ -1,3 +1,6 @@
+use fuel_types::bytes::WORD_SIZE;
+use fuel_types::{AssetId, Bytes32};
+
 /// Consensus configurable parameters used for verifying transactions
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
@@ -44,6 +47,14 @@ impl ConsensusParameters {
         max_predicate_data_length: 1024 * 1024,
         gas_price_factor: 1_000_000_000,
     };
+
+    /// Transaction memory offset in VM runtime
+    pub const fn tx_offset(&self) -> usize {
+        Bytes32::LEN // Tx ID
+            + WORD_SIZE // Tx size
+              // Asset ID/Balance coin input pairs
+            + self.max_inputs as usize * (AssetId::LEN + WORD_SIZE)
+    }
 
     /// Replace the max contract size with the given argument
     pub const fn with_contract_max_size(self, contract_max_size: u64) -> Self {


### PR DESCRIPTION
The consensus parameters will set the maximum inputs count. This will
define the offset of the transaction in the memory since the maximum
inputs count define the reserved assets, pushing the tx offset.

Hence, tx memory offset is no longer a constant for the vm.