### PR TITLE
make ConsensusParams use defaults for missing values

### DIFF
--- a/src/transaction/consensus_parameters.rs
+++ b/src/transaction/consensus_parameters.rs
@@ -4,6 +4,7 @@ use fuel_types::{AssetId, Bytes32};
 /// Consensus configurable parameters used for verifying transactions
 #[derive(Copy, Clone, Debug, PartialEq, Hash)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[cfg_attr(feature = "serde", serde(default))]
 pub struct ConsensusParameters {
     /// Maximum contract size, in bytes.
     pub contract_max_size: u64,


### PR DESCRIPTION
This will allow us to add new params in the future without requiring a chainspec update to deployed environments.