### PR TITLE
Feat: Use in memory Merkle trees

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "FuelVM transaction."
 [dependencies]
 fuel-asm = { version = "0.6", default-features = false }
 fuel-crypto = { version = "0.5", default-features = false }
-fuel-merkle = { version = "0.2", default-features = false, optional = true }
+fuel-merkle = { version = "0.3", default-features = false, optional = true }
 fuel-types = { version = "0.5", default-features = false }
 itertools = { version = "0.10", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["std_rng"], optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ rstest = "0.13"
 
 [features]
 default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
-alloc = ["fuel-types/alloc", "itertools/use_alloc", "serde/alloc"]
+alloc = ["fuel-types/alloc", "itertools/use_alloc", "serde?/alloc"]
 builder = ["alloc", "internals"]
 internals = []
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ alloc = ["fuel-types/alloc", "itertools/use_alloc", "serde?/alloc"]
 builder = ["alloc", "internals"]
 internals = []
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
-std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand/default", "serde?/default"]
+std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand?/default", "serde?/default"]
 serde = ["dep:serde", "fuel-asm/serde", "fuel-crypto/serde", "fuel-types/serde"]
 
 [[test]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ description = "FuelVM transaction."
 [dependencies]
 fuel-asm = { version = "0.6", default-features = false }
 fuel-crypto = { version = "0.5", default-features = false }
-fuel-merkle = { version = "0.3", default-features = false, optional = true }
+fuel-merkle = { version = "0.3", default-features = false }
 fuel-types = { version = "0.5", default-features = false }
 itertools = { version = "0.10", default-features = false }
 rand = { version = "0.8", default-features = false, features = ["std_rng"], optional = true }
@@ -31,12 +31,12 @@ rand = { version = "0.8", default-features = false, features = ["std_rng"] }
 rstest = "0.13"
 
 [features]
-default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle?/default", "fuel-types/default", "std"]
-alloc = ["fuel-merkle", "fuel-types/alloc", "itertools/use_alloc", "serde/alloc"]
+default = ["fuel-asm/default", "fuel-crypto/default", "fuel-merkle/default", "fuel-types/default", "std"]
+alloc = ["fuel-types/alloc", "itertools/use_alloc", "serde/alloc"]
 builder = ["alloc", "internals"]
 internals = []
 random = ["fuel-crypto/random", "fuel-types/random", "rand"]
-std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle?/std", "fuel-types/std", "itertools/default", "rand/default", "serde?/default"]
+std = ["alloc", "fuel-asm/std", "fuel-crypto/std", "fuel-merkle/std", "fuel-types/std", "itertools/default", "rand/default", "serde?/default"]
 serde = ["dep:serde", "fuel-asm/serde", "fuel-crypto/serde", "fuel-types/serde"]
 
 [[test]]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,22 +1,11 @@
-use crate::{Transaction, ValidationError};
-
-#[cfg(feature = "std")]
-use crate::StorageSlot;
+use crate::{StorageSlot, Transaction, ValidationError};
 
 use fuel_crypto::Hasher;
-use fuel_types::{Bytes32, ContractId, Salt};
-
-#[cfg(feature = "std")]
-// use fuel_merkle::{binary, common::StorageMap, sparse};
 use fuel_merkle::binary::in_memory::MerkleTree as BinaryMerkleTree;
 use fuel_merkle::sparse::in_memory::MerkleTree as SparseMerkleTree;
-
-#[cfg(feature = "std")]
-use fuel_types::Bytes8;
+use fuel_types::{Bytes32, Bytes8, ContractId, Salt};
 
 use alloc::vec::Vec;
-
-#[cfg(feature = "std")]
 use core::iter;
 
 #[derive(Debug, Default, Clone, PartialEq, Eq, Hash)]

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -7,7 +7,9 @@ use fuel_crypto::Hasher;
 use fuel_types::{Bytes32, ContractId, Salt};
 
 #[cfg(feature = "std")]
-use fuel_merkle::{binary, common::StorageMap, sparse};
+// use fuel_merkle::{binary, common::StorageMap, sparse};
+use fuel_merkle::binary::in_memory::MerkleTree as BinaryMerkleTree;
+use fuel_merkle::sparse::in_memory::MerkleTree as SparseMerkleTree;
 
 #[cfg(feature = "std")]
 use fuel_types::Bytes8;
@@ -23,13 +25,11 @@ use core::iter;
 pub struct Contract(Vec<u8>);
 
 impl Contract {
-    #[cfg(feature = "std")]
     /// Calculate the code root of the contract, using [`Self::root_from_code`].
     pub fn root(&self) -> Bytes32 {
         Self::root_from_code(self)
     }
 
-    #[cfg(feature = "std")]
     /// Calculate the code root from a contract.
     ///
     /// <https://github.com/FuelLabs/fuel-specs/blob/master/specs/protocol/identifiers.md#contract-id>
@@ -37,8 +37,7 @@ impl Contract {
     where
         B: AsRef<[u8]>,
     {
-        let mut storage = StorageMap::new();
-        let mut tree = binary::MerkleTree::new(&mut storage);
+        let mut tree = BinaryMerkleTree::new();
 
         bytes
             .as_ref()
@@ -58,29 +57,23 @@ impl Contract {
                     b.into()
                 }
             })
-            .try_for_each(|l| tree.push(l.as_ref()))
-            .and_then(|_| tree.root())
-            .expect("In-memory impl should be infallible")
-            .into()
-    }
-
-    #[cfg(feature = "std")]
-    /// Calculate the root of the initial storage slots for this contract
-    pub fn initial_state_root<'a, I>(mut storage_slots: I) -> Bytes32
-    where
-        I: Iterator<Item = &'a StorageSlot>,
-    {
-        let mut storage = StorageMap::new();
-        let mut tree = sparse::MerkleTree::new(&mut storage);
-
-        storage_slots
-            .try_for_each(|s| tree.update(s.key(), s.value().as_ref()))
-            .expect("In-memory impl should be infallible");
+            .for_each(|l| tree.push(l.as_ref()));
 
         tree.root().into()
     }
 
-    #[cfg(feature = "std")]
+    /// Calculate the root of the initial storage slots for this contract
+    pub fn initial_state_root<'a, I>(storage_slots: I) -> Bytes32
+    where
+        I: Iterator<Item = &'a StorageSlot>,
+    {
+        let mut tree = SparseMerkleTree::new();
+
+        storage_slots.for_each(|s| tree.update(s.key(), s.value().as_ref()));
+
+        tree.root().into()
+    }
+
     /// The default state root value without any entries
     pub fn default_state_root() -> Bytes32 {
         Self::initial_state_root(iter::empty())

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -370,14 +370,12 @@ impl Input {
         message_id.into()
     }
 
-    #[cfg(feature = "std")]
     pub fn predicate_owner<P>(predicate: P) -> Address
     where
         P: AsRef<[u8]>,
     {
         use crate::Contract;
 
-        // TODO use as no-std as soon as a no-std merkle backend is available
         let root = Contract::root_from_code(predicate);
 
         (*root).into()


### PR DESCRIPTION
- Upgrades `fuel-merkle` to 0.3.0
- Replaces regular Merkle trees and storage maps with in-memory Merkle trees
- Uses infallible Merkle tree methods and removes `expect` calls
- Enables `Contract` methods into the no-std context