### PR TITLE
remove byte price

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -21,7 +21,6 @@ impl<'a> TransactionBuilder<'a> {
             Default::default(),
             Default::default(),
             Default::default(),
-            Default::default(),
             salt,
             storage_slots,
             Default::default(),
@@ -38,7 +37,6 @@ impl<'a> TransactionBuilder<'a> {
 
     pub fn script(script: Vec<u8>, script_data: Vec<u8>) -> Self {
         let tx = Transaction::script(
-            Default::default(),
             Default::default(),
             Default::default(),
             Default::default(),
@@ -65,12 +63,6 @@ impl<'a> TransactionBuilder<'a> {
 
     pub fn gas_limit(&mut self, gas_limit: Word) -> &mut Self {
         self.tx.set_gas_limit(gas_limit);
-
-        self
-    }
-
-    pub fn byte_price(&mut self, byte_price: Word) -> &mut Self {
-        self.tx.set_byte_price(byte_price);
 
         self
     }

--- a/src/consts.rs
+++ b/src/consts.rs
@@ -4,7 +4,6 @@ use fuel_types::{Bytes32, Salt};
 pub const TRANSACTION_SCRIPT_FIXED_SIZE: usize = WORD_SIZE // Identifier
     + WORD_SIZE // Gas price
     + WORD_SIZE // Gas limit
-    + WORD_SIZE // Byte price
     + WORD_SIZE // Maturity
     + WORD_SIZE // Script size
     + WORD_SIZE // Script data size
@@ -16,7 +15,6 @@ pub const TRANSACTION_SCRIPT_FIXED_SIZE: usize = WORD_SIZE // Identifier
 pub const TRANSACTION_CREATE_FIXED_SIZE: usize = WORD_SIZE // Identifier
     + WORD_SIZE // Gas price
     + WORD_SIZE // Gas limit
-    + WORD_SIZE // Byte price
     + WORD_SIZE // Maturity
     + WORD_SIZE // Bytecode size
     + WORD_SIZE // Bytecode witness index

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -43,7 +43,6 @@ pub enum Transaction {
     Script {
         gas_price: Word,
         gas_limit: Word,
-        byte_price: Word,
         maturity: Word,
         receipts_root: Bytes32,
         script: Vec<u8>,
@@ -57,7 +56,6 @@ pub enum Transaction {
     Create {
         gas_price: Word,
         gas_limit: Word,
-        byte_price: Word,
         maturity: Word,
         bytecode_length: Word,
         bytecode_witness_index: u8,
@@ -83,7 +81,6 @@ impl Default for Transaction {
             0,
             ConsensusParameters::DEFAULT.max_gas_per_tx,
             0,
-            0,
             script,
             vec![],
             vec![],
@@ -97,7 +94,6 @@ impl Transaction {
     pub const fn script(
         gas_price: Word,
         gas_limit: Word,
-        byte_price: Word,
         maturity: Word,
         script: Vec<u8>,
         script_data: Vec<u8>,
@@ -110,7 +106,6 @@ impl Transaction {
         Self::Script {
             gas_price,
             gas_limit,
-            byte_price,
             maturity,
             receipts_root,
             script,
@@ -125,7 +120,6 @@ impl Transaction {
     pub fn create(
         gas_price: Word,
         gas_limit: Word,
-        byte_price: Word,
         maturity: Word,
         bytecode_witness_index: u8,
         salt: Salt,
@@ -144,7 +138,6 @@ impl Transaction {
         Self::Create {
             gas_price,
             gas_limit,
-            byte_price,
             maturity,
             bytecode_length,
             bytecode_witness_index,
@@ -242,20 +235,6 @@ impl Transaction {
         match self {
             Self::Script { gas_limit, .. } => *gas_limit = limit,
             Self::Create { gas_limit, .. } => *gas_limit = limit,
-        }
-    }
-
-    pub const fn byte_price(&self) -> Word {
-        match self {
-            Self::Script { byte_price, .. } => *byte_price,
-            Self::Create { byte_price, .. } => *byte_price,
-        }
-    }
-
-    pub fn set_byte_price(&mut self, price: Word) {
-        match self {
-            Self::Script { byte_price, .. } => *byte_price = price,
-            Self::Create { byte_price, .. } => *byte_price = price,
         }
     }
 
@@ -495,7 +474,6 @@ mod tests {
         let script_with_no_witnesses = Transaction::Script {
             gas_price: 0,
             gas_limit: 0,
-            byte_price: 0,
             maturity: 0,
             receipts_root: Default::default(),
             script: vec![],
@@ -508,7 +486,6 @@ mod tests {
         let script_with_witnesses = Transaction::Script {
             gas_price: 0,
             gas_limit: 0,
-            byte_price: 0,
             maturity: 0,
             receipts_root: Default::default(),
             script: vec![],
@@ -527,7 +504,6 @@ mod tests {
         let create_with_no_witnesses = Transaction::Create {
             gas_price: 0,
             gas_limit: 0,
-            byte_price: 0,
             maturity: 0,
             bytecode_length: 0,
             bytecode_witness_index: 0,
@@ -541,7 +517,6 @@ mod tests {
         let create_with_witnesses = Transaction::Create {
             gas_price: 0,
             gas_limit: 0,
-            byte_price: 0,
             maturity: 0,
             bytecode_length: 0,
             bytecode_witness_index: 0,

--- a/src/transaction/consensus_parameters.rs
+++ b/src/transaction/consensus_parameters.rs
@@ -28,6 +28,8 @@ pub struct ConsensusParameters {
     pub max_predicate_data_length: u64,
     /// Factor to convert between gas and transaction assets value.
     pub gas_price_factor: u64,
+    /// A fixed ratio linking metered bytes to gas price
+    pub gas_per_byte: u64,
     /// Maximum length of message data, in bytes.
     pub max_message_data_length: u64,
 }
@@ -46,6 +48,7 @@ impl ConsensusParameters {
         max_predicate_length: 1024 * 1024,
         max_predicate_data_length: 1024 * 1024,
         gas_price_factor: 1_000_000_000,
+        gas_per_byte: 4,
         max_message_data_length: 1024 * 1024,
     };
 
@@ -70,6 +73,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -86,6 +90,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -103,6 +108,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -119,6 +125,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -136,6 +143,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -152,6 +160,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -169,6 +178,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -185,6 +195,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -202,6 +213,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -218,6 +230,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -235,6 +248,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -251,6 +265,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -268,6 +283,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -284,6 +300,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -301,6 +318,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -317,6 +335,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -334,6 +353,7 @@ impl ConsensusParameters {
             max_storage_slots,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -350,6 +370,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -367,6 +388,7 @@ impl ConsensusParameters {
             max_storage_slots,
             max_predicate_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -383,6 +405,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -400,6 +423,7 @@ impl ConsensusParameters {
             max_storage_slots,
             max_predicate_length,
             max_predicate_data_length,
+            gas_per_byte,
             max_message_data_length,
             ..
         } = self;
@@ -416,6 +440,41 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
+            max_message_data_length,
+        }
+    }
+
+    pub const fn with_gas_per_byte(self, gas_per_byte: u64) -> Self {
+        let Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            max_message_data_length,
+            ..
+        } = self;
+
+        Self {
+            contract_max_size,
+            max_inputs,
+            max_outputs,
+            max_witnesses,
+            max_gas_per_tx,
+            max_script_length,
+            max_script_data_length,
+            max_storage_slots,
+            max_predicate_length,
+            max_predicate_data_length,
+            gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -434,6 +493,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             ..
         } = self;
 
@@ -449,6 +509,7 @@ impl ConsensusParameters {
             max_predicate_length,
             max_predicate_data_length,
             gas_price_factor,
+            gas_per_byte,
             max_message_data_length,
         }
     }
@@ -478,5 +539,6 @@ pub mod default_parameters {
     pub const MAX_PREDICATE_DATA_LENGTH: u64 =
         ConsensusParameters::DEFAULT.max_predicate_data_length;
     pub const GAS_PRICE_FACTOR: u64 = ConsensusParameters::DEFAULT.gas_price_factor;
+    pub const GAS_PER_BYTE: u64 = ConsensusParameters::DEFAULT.gas_per_byte;
     pub const MAX_MESSAGE_DATA_LENGTH: u64 = ConsensusParameters::DEFAULT.max_message_data_length;
 }

--- a/src/transaction/id.rs
+++ b/src/transaction/id.rs
@@ -194,7 +194,6 @@ mod tests {
     fn assert_id_common_attrs(tx: &Transaction) {
         assert_id_ne(tx, |t| t.set_gas_price(t.gas_price().not()));
         assert_id_ne(tx, |t| t.set_gas_limit(t.gas_limit().not()));
-        assert_id_ne(tx, |t| t.set_byte_price(t.byte_price().not()));
         assert_id_ne(tx, |t| t.set_maturity(t.maturity().not()));
 
         if !tx.inputs().is_empty() {
@@ -319,7 +318,6 @@ mod tests {
                                 rng.next_u64(),
                                 rng.next_u64(),
                                 rng.next_u64(),
-                                rng.next_u64(),
                                 script.clone(),
                                 script_data.clone(),
                                 inputs.clone(),
@@ -345,7 +343,6 @@ mod tests {
                         let tx = Transaction::create(
                             rng.next_u64(),
                             ConsensusParameters::DEFAULT.max_gas_per_tx,
-                            rng.next_u64(),
                             rng.next_u64(),
                             rng.next_u32().to_be_bytes()[0],
                             rng.gen(),

--- a/src/transaction/txio.rs
+++ b/src/transaction/txio.rs
@@ -17,7 +17,7 @@ impl Transaction {
     }
 }
 
-impl bytes::SizedBytes for Transaction {
+impl SizedBytes for Transaction {
     fn serialized_size(&self) -> usize {
         let inputs = self
             .inputs()
@@ -66,7 +66,6 @@ impl io::Read for Transaction {
             Self::Script {
                 gas_price,
                 gas_limit,
-                byte_price,
                 maturity,
                 receipts_root,
                 script,
@@ -79,7 +78,6 @@ impl io::Read for Transaction {
                 let buf = bytes::store_number_unchecked(buf, TransactionRepr::Script as Word);
                 let buf = bytes::store_number_unchecked(buf, *gas_price);
                 let buf = bytes::store_number_unchecked(buf, *gas_limit);
-                let buf = bytes::store_number_unchecked(buf, *byte_price);
                 let buf = bytes::store_number_unchecked(buf, *maturity);
                 let buf = bytes::store_number_unchecked(buf, script.len() as Word);
                 let buf = bytes::store_number_unchecked(buf, script_data.len() as Word);
@@ -97,7 +95,6 @@ impl io::Read for Transaction {
             Self::Create {
                 gas_price,
                 gas_limit,
-                byte_price,
                 maturity,
                 bytecode_length,
                 bytecode_witness_index,
@@ -111,7 +108,6 @@ impl io::Read for Transaction {
                 let buf = bytes::store_number_unchecked(buf, TransactionRepr::Create as Word);
                 let buf = bytes::store_number_unchecked(buf, *gas_price);
                 let buf = bytes::store_number_unchecked(buf, *gas_limit);
-                let buf = bytes::store_number_unchecked(buf, *byte_price);
                 let buf = bytes::store_number_unchecked(buf, *maturity);
                 let buf = bytes::store_number_unchecked(buf, *bytecode_length);
                 let buf = bytes::store_number_unchecked(buf, *bytecode_witness_index);
@@ -149,7 +145,7 @@ impl io::Read for Transaction {
     }
 }
 
-impl io::Write for Transaction {
+impl Write for Transaction {
     fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
         if buf.len() < WORD_SIZE {
             return Err(bytes::eof());
@@ -169,7 +165,6 @@ impl io::Write for Transaction {
                 // Safety: buffer size is checked
                 let (gas_price, buf) = unsafe { bytes::restore_number_unchecked(buf) };
                 let (gas_limit, buf) = unsafe { bytes::restore_number_unchecked(buf) };
-                let (byte_price, buf) = unsafe { bytes::restore_number_unchecked(buf) };
                 let (maturity, buf) = unsafe { bytes::restore_number_unchecked(buf) };
                 let (script_len, buf) = unsafe { bytes::restore_usize_unchecked(buf) };
                 let (script_data_len, buf) = unsafe { bytes::restore_usize_unchecked(buf) };
@@ -210,7 +205,6 @@ impl io::Write for Transaction {
                 *self = Transaction::Script {
                     gas_price,
                     gas_limit,
-                    byte_price,
                     maturity,
                     receipts_root,
                     script,
@@ -233,7 +227,6 @@ impl io::Write for Transaction {
                 // Safety: buffer size is checked
                 let (gas_price, buf) = unsafe { bytes::restore_number_unchecked(buf) };
                 let (gas_limit, buf) = unsafe { bytes::restore_number_unchecked(buf) };
-                let (byte_price, buf) = unsafe { bytes::restore_number_unchecked(buf) };
                 let (maturity, buf) = unsafe { bytes::restore_number_unchecked(buf) };
                 let (bytecode_length, buf) = unsafe { bytes::restore_number_unchecked(buf) };
                 let (bytecode_witness_index, buf) = unsafe { bytes::restore_u8_unchecked(buf) };
@@ -276,7 +269,6 @@ impl io::Write for Transaction {
                 *self = Self::Create {
                     gas_price,
                     gas_limit,
-                    byte_price,
                     maturity,
                     bytecode_length,
                     bytecode_witness_index,

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -506,7 +506,6 @@ fn transaction() {
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
-            rng.next_u64(),
             rng.gen::<Witness>().into_inner(),
             rng.gen::<Witness>().into_inner(),
             vec![i.clone()],
@@ -514,7 +513,6 @@ fn transaction() {
             vec![w.clone()],
         ),
         Transaction::script(
-            rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
@@ -528,7 +526,6 @@ fn transaction() {
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
-            rng.next_u64(),
             rng.gen::<Witness>().into_inner(),
             vec![],
             vec![i.clone()],
@@ -539,7 +536,6 @@ fn transaction() {
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
-            rng.next_u64(),
             vec![],
             vec![],
             vec![i.clone()],
@@ -550,7 +546,6 @@ fn transaction() {
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
-            rng.next_u64(),
             vec![],
             vec![],
             vec![],
@@ -561,7 +556,6 @@ fn transaction() {
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
-            rng.next_u64(),
             vec![],
             vec![],
             vec![],
@@ -569,7 +563,6 @@ fn transaction() {
             vec![w.clone()],
         ),
         Transaction::script(
-            rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
             rng.next_u64(),
@@ -582,7 +575,6 @@ fn transaction() {
         Transaction::create(
             rng.next_u64(),
             ConsensusParameters::DEFAULT.max_gas_per_tx,
-            rng.next_u64(),
             rng.next_u64(),
             rng.gen(),
             rng.gen(),
@@ -595,7 +587,6 @@ fn transaction() {
             rng.next_u64(),
             ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
-            rng.next_u64(),
             rng.gen(),
             rng.gen(),
             vec![s],
@@ -606,7 +597,6 @@ fn transaction() {
         Transaction::create(
             rng.next_u64(),
             ConsensusParameters::DEFAULT.max_gas_per_tx,
-            rng.next_u64(),
             rng.next_u64(),
             rng.gen(),
             rng.gen(),
@@ -619,7 +609,6 @@ fn transaction() {
             rng.next_u64(),
             ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
-            rng.next_u64(),
             rng.gen(),
             rng.gen(),
             vec![],
@@ -631,7 +620,6 @@ fn transaction() {
             rng.next_u64(),
             ConsensusParameters::DEFAULT.max_gas_per_tx,
             rng.next_u64(),
-            rng.next_u64(),
             rng.gen(),
             rng.gen(),
             vec![],
@@ -642,7 +630,6 @@ fn transaction() {
         Transaction::create(
             rng.next_u64(),
             ConsensusParameters::DEFAULT.max_gas_per_tx,
-            rng.next_u64(),
             rng.next_u64(),
             rng.gen(),
             rng.gen(),
@@ -660,7 +647,6 @@ fn create_input_coin_data_offset() {
 
     let gas_price = 100;
     let gas_limit = 1000;
-    let byte_price = 20;
     let maturity = 10;
     let bytecode_witness_index = 0x00;
     let salt = rng.gen();
@@ -715,7 +701,6 @@ fn create_input_coin_data_offset() {
                     let mut tx = Transaction::create(
                         gas_price,
                         gas_limit,
-                        byte_price,
                         maturity,
                         bytecode_witness_index,
                         salt,
@@ -760,7 +745,6 @@ fn script_input_coin_data_offset() {
 
     let gas_price = 100;
     let gas_limit = 1000;
-    let byte_price = 20;
     let maturity = 10;
 
     let script: Vec<Vec<u8>> = vec![vec![], generate_bytes(rng)];
@@ -822,7 +806,6 @@ fn script_input_coin_data_offset() {
                         let mut tx = Transaction::script(
                             gas_price,
                             gas_limit,
-                            byte_price,
                             maturity,
                             script.clone(),
                             script_data.clone(),

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -18,7 +18,6 @@ fn gas_limit() {
     Transaction::script(
         rng.gen(),
         PARAMS.max_gas_per_tx,
-        rng.gen(),
         maturity,
         generate_bytes(rng),
         generate_bytes(rng),
@@ -32,7 +31,6 @@ fn gas_limit() {
     Transaction::create(
         rng.gen(),
         PARAMS.max_gas_per_tx,
-        rng.gen(),
         maturity,
         0,
         rng.gen(),
@@ -47,7 +45,6 @@ fn gas_limit() {
     let err = Transaction::script(
         rng.gen(),
         PARAMS.max_gas_per_tx + 1,
-        rng.gen(),
         maturity,
         generate_bytes(rng),
         generate_bytes(rng),
@@ -64,7 +61,6 @@ fn gas_limit() {
     let err = Transaction::create(
         rng.gen(),
         PARAMS.max_gas_per_tx + 1,
-        rng.gen(),
         maturity,
         0,
         rng.gen(),
@@ -89,7 +85,6 @@ fn maturity() {
     Transaction::script(
         rng.gen(),
         PARAMS.max_gas_per_tx,
-        rng.gen(),
         block_height,
         vec![],
         vec![],
@@ -103,7 +98,6 @@ fn maturity() {
     Transaction::create(
         rng.gen(),
         PARAMS.max_gas_per_tx,
-        rng.gen(),
         1000,
         0,
         rng.gen(),
@@ -118,7 +112,6 @@ fn maturity() {
     let err = Transaction::script(
         rng.gen(),
         PARAMS.max_gas_per_tx,
-        rng.gen(),
         1001,
         vec![],
         vec![],
@@ -135,7 +128,6 @@ fn maturity() {
     let err = Transaction::create(
         rng.gen(),
         PARAMS.max_gas_per_tx,
-        rng.gen(),
         1001,
         0,
         rng.gen(),
@@ -607,7 +599,6 @@ fn create() {
     let err = Transaction::create(
         rng.gen(),
         PARAMS.max_gas_per_tx,
-        rng.gen(),
         maturity,
         0,
         rng.gen(),
@@ -699,7 +690,6 @@ fn tx_id_bytecode_len() {
 
     let maturity = 100;
     let gas_price = rng.gen();
-    let byte_price = rng.gen();
     let salt = rng.gen();
 
     let w_a = vec![0xfau8; 4].into();
@@ -709,7 +699,6 @@ fn tx_id_bytecode_len() {
     let tx_a = Transaction::create(
         gas_price,
         PARAMS.max_gas_per_tx,
-        byte_price,
         maturity,
         0,
         salt,
@@ -722,7 +711,6 @@ fn tx_id_bytecode_len() {
     let tx_b = Transaction::create(
         gas_price,
         PARAMS.max_gas_per_tx,
-        byte_price,
         maturity,
         0,
         salt,
@@ -735,7 +723,6 @@ fn tx_id_bytecode_len() {
     let tx_c = Transaction::create(
         gas_price,
         PARAMS.max_gas_per_tx,
-        byte_price,
         maturity,
         0,
         salt,


### PR DESCRIPTION
fixes: #139 

Remove byte price field as we now have the `GTF` opcode for future proof txs and don't need to pre-emptively include fields we aren't ready for yet.