### PR TITLE
Add `From<&Transaction>` for `TransactionRepr`

### DIFF
--- a/src/transaction/repr.rs
+++ b/src/transaction/repr.rs
@@ -1,3 +1,5 @@
+use crate::Transaction;
+
 #[cfg(feature = "std")]
 use fuel_types::Word;
 
@@ -5,6 +7,15 @@ use fuel_types::Word;
 pub enum TransactionRepr {
     Script = 0x00,
     Create = 0x01,
+}
+
+impl From<&Transaction> for TransactionRepr {
+    fn from(tx: &Transaction) -> Self {
+        match tx {
+            Transaction::Script { .. } => Self::Script,
+            Transaction::Create { .. } => Self::Create,
+        }
+    }
 }
 
 #[cfg(feature = "std")]


### PR DESCRIPTION
The transaction representation will have to be constructed from an
existing transaction memory instance in order to implement some metadata
opcodes such as `GTF`