### PR TITLE
Revert "Deny clippy warnings and dbg_macro lint"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
-  RUSTFLAGS: -D warnings -D clippy::dbg_macro
 
 jobs:
   cancel-previous-runs:

--- a/src/checked_transaction.rs
+++ b/src/checked_transaction.rs
@@ -225,7 +225,7 @@ mod tests {
         let gas_limit = 1000;
         let tx = signed_message_tx(rng, gas_price, gas_limit, input_amount, output_amont);
 
-        let checked = CheckedTransaction::check(tx, 0, &ConsensusParameters::DEFAULT)
+        let checked = CheckedTransaction::check(tx.clone(), 0, &ConsensusParameters::DEFAULT)
             .expect("Expected valid transaction");
 
         // verify available balance was decreased by max fee
@@ -246,7 +246,7 @@ mod tests {
         let gas_limit = 1000;
         let tx = signed_message_tx(rng, gas_price, gas_limit, input_amount, output_amont);
 
-        let checked = CheckedTransaction::check(tx, 0, &ConsensusParameters::DEFAULT)
+        let checked = CheckedTransaction::check(tx.clone(), 0, &ConsensusParameters::DEFAULT)
             .expect("Expected valid transaction");
 
         // verify available balance was decreased by max fee
@@ -390,8 +390,9 @@ mod tests {
             .add_witness(Default::default())
             .finalize();
 
-        let checked = CheckedTransaction::check(tx, 0, &ConsensusParameters::DEFAULT)
-            .expect_err("Expected invalid transaction");
+        let checked = CheckedTransaction::check(tx.clone(), 0, &ConsensusParameters::DEFAULT)
+            .err()
+            .expect("Expected invalid transaction");
 
         // assert that tx without base input assets fails
         assert_eq!(
@@ -416,7 +417,8 @@ mod tests {
         let transaction = base_asset_tx(rng, input_amount, gas_price, gas_limit);
 
         let err = CheckedTransaction::check(transaction, 0, &params)
-            .expect_err("insufficient fee amount expected");
+            .err()
+            .expect("insufficient fee amount expected");
 
         let provided = match err {
             ValidationError::InsufficientFeeAmount { provided, .. } => provided,
@@ -440,7 +442,8 @@ mod tests {
         let transaction = base_asset_tx(rng, input_amount, gas_price, gas_limit);
 
         let err = CheckedTransaction::check(transaction, 0, &params)
-            .expect_err("insufficient fee amount expected");
+            .err()
+            .expect("insufficient fee amount expected");
 
         let provided = match err {
             ValidationError::InsufficientFeeAmount { provided, .. } => provided,
@@ -460,10 +463,11 @@ mod tests {
         let params = ConsensusParameters::default().with_gas_price_factor(1);
         let transaction = base_asset_tx(rng, input_amount, gas_price, gas_limit);
 
-        let err =
-            CheckedTransaction::check(transaction, 0, &params).expect_err("overflow expected");
+        let err = CheckedTransaction::check(transaction, 0, &params)
+            .err()
+            .expect("overflow expected");
 
-        assert_eq!(err, ValidationError::ArithmeticOverflow);
+        assert_eq!(err, ValidationError::ArithmeticOverflow.into());
     }
 
     #[test]
@@ -476,10 +480,11 @@ mod tests {
 
         let transaction = base_asset_tx(rng, input_amount, gas_price, gas_limit);
 
-        let err =
-            CheckedTransaction::check(transaction, 0, &params).expect_err("overflow expected");
+        let err = CheckedTransaction::check(transaction, 0, &params)
+            .err()
+            .expect("overflow expected");
 
-        assert_eq!(err, ValidationError::ArithmeticOverflow);
+        assert_eq!(err, ValidationError::ArithmeticOverflow.into());
     }
 
     #[test]
@@ -500,8 +505,9 @@ mod tests {
             .add_output(Output::change(rng.gen(), 0, any_asset))
             .finalize();
 
-        let checked = CheckedTransaction::check(tx, 0, &ConsensusParameters::DEFAULT)
-            .expect_err("Expected valid transaction");
+        let checked = CheckedTransaction::check(tx.clone(), 0, &ConsensusParameters::DEFAULT)
+            .err()
+            .expect("Expected valid transaction");
 
         assert_eq!(
             ValidationError::InsufficientInputAmount {
@@ -517,7 +523,7 @@ mod tests {
         tx: &Transaction,
         params: &ConsensusParameters,
     ) -> Result<bool, ValidationError> {
-        let available_balances = CheckedTransaction::_initial_free_balances(tx, params)?;
+        let available_balances = CheckedTransaction::_initial_free_balances(&tx, &params)?;
         // cant overflow as metered bytes * gas_per_byte < u64::MAX
         let bytes = (tx.metered_bytes_size() as u128)
             * params.gas_per_byte as u128
@@ -536,7 +542,7 @@ mod tests {
         tx: &Transaction,
         params: &ConsensusParameters,
     ) -> Result<bool, ValidationError> {
-        let available_balances = CheckedTransaction::_initial_free_balances(tx, params)?;
+        let available_balances = CheckedTransaction::_initial_free_balances(&tx, &params)?;
         // cant overflow as metered bytes * gas_per_byte < u64::MAX
         let bytes = (tx.metered_bytes_size() as u128)
             * params.gas_per_byte as u128

--- a/tests/bytes.rs
+++ b/tests/bytes.rs
@@ -62,12 +62,14 @@ where
 
             let err = d
                 .read(buffer.as_mut_slice())
-                .expect_err("Insufficient buffer should fail!");
+                .err()
+                .expect("Insufficient buffer should fail!");
             assert_eq!(io::ErrorKind::UnexpectedEof, err.kind());
 
             let err = d_p
                 .write(buffer.as_slice())
-                .expect_err("Insufficient buffer should fail!");
+                .err()
+                .expect("Insufficient buffer should fail!");
             assert_eq!(io::ErrorKind::UnexpectedEof, err.kind());
 
             if buffer.is_empty() {

--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -48,7 +48,7 @@ fn iow_offset() {
                 assert_eq!(offset, offset_p);
             });
 
-            if let Some(offset) = tx.receipts_root_offset() {
+            tx.receipts_root_offset().map(|offset| {
                 let receipts_root = rng.gen();
 
                 tx.set_receipts_root(receipts_root);
@@ -57,6 +57,6 @@ fn iow_offset() {
                 let receipts_root_p = &bytes[offset..offset + Bytes32::LEN];
 
                 assert_eq!(&receipts_root[..], receipts_root_p);
-            }
+            });
         });
 }

--- a/tests/valid_cases/input.rs
+++ b/tests/valid_cases/input.rs
@@ -92,7 +92,8 @@ fn coin_signed() {
     let block_height = rng.gen();
     let err = tx
         .validate(block_height, &Default::default())
-        .expect_err("Expected failure");
+        .err()
+        .expect("Expected failure");
 
     assert_eq!(ValidationError::InputWitnessIndexBounds { index: 0 }, err);
 }
@@ -256,7 +257,8 @@ fn message() {
     let block_height = rng.gen();
     let err = tx
         .validate(block_height, &Default::default())
-        .expect_err("Expected failure");
+        .err()
+        .expect("Expected failure");
 
     assert_eq!(ValidationError::InputWitnessIndexBounds { index: 0 }, err,);
 
@@ -276,7 +278,8 @@ fn message() {
         generate_bytes(rng),
     )
     .validate(1, &txhash, &[], &[], &Default::default())
-    .expect_err("Expected failure");
+    .err()
+    .expect("Expected failure");
 
     assert_eq!(ValidationError::InputPredicateOwner { index: 1 }, err);
 
@@ -293,7 +296,8 @@ fn message() {
         data.clone(),
     )
     .validate(1, &txhash, &[], &[vec![].into()], &Default::default())
-    .expect_err("expected max data length error");
+    .err()
+    .expect("expected max data length error");
 
     assert_eq!(ValidationError::InputMessageDataLength { index: 1 }, err,);
 
@@ -304,12 +308,13 @@ fn message() {
         rng.gen(),
         rng.gen(),
         rng.gen(),
-        data,
+        data.clone(),
         generate_nonempty_padded_bytes(rng),
         generate_bytes(rng),
     )
     .validate(1, &txhash, &[], &[], &Default::default())
-    .expect_err("expected max data length error");
+    .err()
+    .expect("expected max data length error");
 
     assert_eq!(ValidationError::InputMessageDataLength { index: 1 }, err,);
 
@@ -327,7 +332,8 @@ fn message() {
         generate_bytes(rng),
     )
     .validate(1, &txhash, &[], &[], &Default::default())
-    .expect_err("expected max predicate length error");
+    .err()
+    .expect("expected max predicate length error");
 
     assert_eq!(ValidationError::InputPredicateLength { index: 1 }, err,);
 
@@ -345,7 +351,8 @@ fn message() {
         predicate_data,
     )
     .validate(1, &txhash, &[], &[], &Default::default())
-    .expect_err("expected max predicate data length error");
+    .err()
+    .expect("expected max predicate data length error");
 
     assert_eq!(ValidationError::InputPredicateDataLength { index: 1 }, err,);
 }
@@ -364,7 +371,8 @@ fn transaction_with_duplicate_coin_inputs_is_invalid() {
         .add_witness(rng.gen())
         .finalize()
         .validate_without_signature(0, &Default::default())
-        .expect_err("Expected validation failure");
+        .err()
+        .expect("Expected validation failure");
 
     assert_eq!(err, ValidationError::DuplicateInputUtxoId { utxo_id });
 }
@@ -392,7 +400,8 @@ fn transaction_with_duplicate_message_inputs_is_invalid() {
         .add_witness(rng.gen())
         .finalize()
         .validate_without_signature(0, &Default::default())
-        .expect_err("Expected validation failure");
+        .err()
+        .expect("Expected validation failure");
 
     assert_eq!(err, ValidationError::DuplicateMessageInputId { message_id });
 }
@@ -415,7 +424,8 @@ fn transaction_with_duplicate_contract_inputs_is_invalid() {
         .add_output(p)
         .finalize()
         .validate_without_signature(0, &Default::default())
-        .expect_err("Expected validation failure");
+        .err()
+        .expect("Expected validation failure");
 
     assert_eq!(
         err,

--- a/tests/valid_cases/transaction.rs
+++ b/tests/valid_cases/transaction.rs
@@ -53,7 +53,8 @@ fn gas_limit() {
         vec![],
     )
     .validate(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionGasLimit, err);
 
@@ -69,7 +70,8 @@ fn gas_limit() {
         vec![generate_bytes(rng).into()],
     )
     .validate(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionGasLimit, err);
 }
@@ -118,7 +120,8 @@ fn maturity() {
         vec![],
     )
     .validate(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionMaturity, err);
 
@@ -134,7 +137,8 @@ fn maturity() {
         vec![rng.gen()],
     )
     .validate(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionMaturity, err);
 }
@@ -229,7 +233,8 @@ fn max_iow() {
     let err = builder
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionInputsMax, err);
 
@@ -260,7 +265,8 @@ fn max_iow() {
     let err = builder
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionOutputsMax, err);
 
@@ -291,7 +297,8 @@ fn max_iow() {
     let err = builder
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionWitnessesMax, err);
 }
@@ -331,7 +338,8 @@ fn output_change_asset_id() {
         .add_output(Output::change(rng.gen(), rng.next_u64(), a))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(
         ValidationError::TransactionOutputChangeAssetIdDuplicated,
@@ -348,7 +356,8 @@ fn output_change_asset_id() {
         .add_output(Output::change(rng.gen(), rng.next_u64(), c))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert!(matches!(
         err,
@@ -365,7 +374,8 @@ fn output_change_asset_id() {
         .add_output(Output::coin(rng.gen(), rng.next_u64(), c))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert!(matches!(
         err,
@@ -407,7 +417,8 @@ fn script() {
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(
         ValidationError::TransactionScriptOutputContractCreated { index: 0 },
@@ -425,7 +436,8 @@ fn script() {
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionScriptLength, err);
 
@@ -440,7 +452,8 @@ fn script() {
     .add_output(Output::contract_created(rng.gen(), rng.gen()))
     .finalize()
     .validate(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionScriptDataLength, err);
 }
@@ -472,7 +485,8 @@ fn create() {
         .add_output(Output::contract(0, rng.gen(), rng.gen()))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(
         err,
@@ -487,7 +501,8 @@ fn create() {
         .add_output(Output::variable(rng.gen(), rng.gen(), rng.gen()))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(
         err,
@@ -504,7 +519,8 @@ fn create() {
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(
         err,
@@ -523,7 +539,8 @@ fn create() {
         .add_output(Output::change(rng.gen(), rng.gen(), asset_id))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(
         err,
@@ -540,7 +557,8 @@ fn create() {
         .add_output(Output::contract_created(rng.gen(), rng.gen()))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(
         err,
@@ -573,7 +591,8 @@ fn create() {
     .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
     .finalize()
     .validate(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(err, ValidationError::TransactionCreateBytecodeLen);
 
@@ -589,7 +608,8 @@ fn create() {
         vec![],
     )
     .validate_without_signature(block_height, &PARAMS)
-    .expect_err("Expected erroneous transaction");
+    .err()
+    .expect("Expected erroneous transaction");
 
     assert_eq!(err, ValidationError::TransactionCreateBytecodeWitnessIndex);
 
@@ -639,7 +659,8 @@ fn create() {
         .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
         .finalize()
         .validate(block_height, &PARAMS)
-        .expect_err("Expected erroneous transaction");
+        .err()
+        .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionCreateStorageSlotMax, err);
 
@@ -657,7 +678,8 @@ fn create() {
             .add_output(Output::change(rng.gen(), rng.gen(), AssetId::default()))
             .finalize()
             .validate(block_height, &PARAMS)
-            .expect_err("Expected erroneous transaction");
+            .err()
+            .expect("Expected erroneous transaction");
 
     assert_eq!(ValidationError::TransactionCreateStorageSlotOrder, err);
 }


### PR DESCRIPTION
Reverts FuelLabs/fuel-tx#163

We might prioritize the big changes to allow `SMO`, such as https://github.com/FuelLabs/fuel-tx/pull/162 , before landing PRs that are non-critical