### PR TITLE
Add tx, input, output helper fns

### DIFF
--- a/src/consts.rs
+++ b/src/consts.rs
@@ -23,3 +23,5 @@ pub const TRANSACTION_CREATE_FIXED_SIZE: usize = WORD_SIZE // Identifier
     + WORD_SIZE // Outputs size
     + WORD_SIZE // Witnesses size
     + Salt::LEN; // Salt
+
+pub const TRANSACTION_CREATE_SALT_OFFSET: usize = TRANSACTION_CREATE_FIXED_SIZE - Salt::LEN;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,9 @@ extern crate alloc;
 pub mod consts;
 
 pub use fuel_asm::{InstructionResult, PanicReason};
-pub use fuel_types::{Address, AssetId, Bytes32, Bytes4, Bytes64, Bytes8, ContractId, Salt, Word};
+pub use fuel_types::{
+    Address, AssetId, Bytes32, Bytes4, Bytes64, Bytes8, ContractId, MessageId, Salt, Word,
+};
 
 #[cfg(feature = "builder")]
 mod builder;
@@ -38,8 +40,8 @@ pub use receipt::{Receipt, ScriptExecutionResult};
 
 #[cfg(feature = "alloc")]
 pub use transaction::{
-    ConsensusParameters, Input, Metadata, Output, StorageSlot, Transaction, TransactionFee,
-    TransactionRepr, TxId, UtxoId, ValidationError, Witness,
+    ConsensusParameters, Input, InputRepr, Metadata, Output, OutputRepr, StorageSlot, Transaction,
+    TransactionFee, TransactionRepr, TxId, UtxoId, ValidationError, Witness,
 };
 
 #[cfg(feature = "alloc")]

--- a/src/transaction/types.rs
+++ b/src/transaction/types.rs
@@ -4,8 +4,8 @@ mod storage;
 mod utxo_id;
 mod witness;
 
-pub use input::Input;
-pub use output::Output;
+pub use input::{Input, InputRepr};
+pub use output::{Output, OutputRepr};
 pub use storage::StorageSlot;
 pub use utxo_id::UtxoId;
 pub use witness::Witness;

--- a/src/transaction/types/input/consts.rs
+++ b/src/transaction/types/input/consts.rs
@@ -1,0 +1,37 @@
+use crate::UtxoId;
+
+use fuel_types::bytes::WORD_SIZE;
+use fuel_types::{Address, AssetId, Bytes32, ContractId, MessageId};
+
+pub(super) const INPUT_UTXO_ID_OFFSET: usize = WORD_SIZE; // Identifier
+pub(super) const INPUT_COIN_OWNER_OFFSET: usize = INPUT_UTXO_ID_OFFSET + UtxoId::LEN;
+pub(super) const INPUT_COIN_ASSET_ID_OFFSET: usize = INPUT_COIN_OWNER_OFFSET
+    + Address::LEN // Owner
+    + WORD_SIZE; // Amount
+pub(super) const INPUT_COIN_FIXED_SIZE: usize = INPUT_COIN_ASSET_ID_OFFSET
+    + AssetId::LEN // AssetId
+    + WORD_SIZE // Witness index
+    + WORD_SIZE // Maturity
+    + WORD_SIZE // Predicate size
+    + WORD_SIZE; // Predicate data size
+
+pub(super) const INPUT_CONTRACT_BALANCE_ROOT_OFFSET: usize = INPUT_UTXO_ID_OFFSET + UtxoId::LEN; // UtxoId
+pub(super) const INPUT_CONTRACT_STATE_ROOT_OFFSET: usize =
+    INPUT_CONTRACT_BALANCE_ROOT_OFFSET + Bytes32::LEN; // Balance root
+pub(super) const INPUT_CONTRACT_ID_OFFSET: usize = INPUT_CONTRACT_STATE_ROOT_OFFSET + Bytes32::LEN; // State root
+pub(super) const INPUT_CONTRACT_SIZE: usize = INPUT_CONTRACT_ID_OFFSET + ContractId::LEN; // Contract address
+
+pub(super) const INPUT_MESSAGE_ID_OFFSET: usize = WORD_SIZE; // Identifier
+pub(super) const INPUT_MESSAGE_SENDER_OFFSET: usize = INPUT_MESSAGE_ID_OFFSET + MessageId::LEN; // message_id
+pub(super) const INPUT_MESSAGE_RECIPIENT_OFFSET: usize = INPUT_MESSAGE_SENDER_OFFSET + Address::LEN; // sender
+pub(super) const INPUT_MESSAGE_OWNER_OFFSET: usize = INPUT_MESSAGE_RECIPIENT_OFFSET
+    + Address::LEN // recipient
+    + WORD_SIZE //amount
+    + WORD_SIZE; // nonce
+
+pub(super) const INPUT_MESSAGE_FIXED_SIZE: usize = INPUT_MESSAGE_OWNER_OFFSET
+    + Address::LEN // owner
+    + WORD_SIZE // witness_index
+    + WORD_SIZE // Data size
+    + WORD_SIZE // Predicate size
+    + WORD_SIZE; // Predicate data size

--- a/src/transaction/types/input/repr.rs
+++ b/src/transaction/types/input/repr.rs
@@ -1,0 +1,126 @@
+use super::consts::*;
+use super::Input;
+
+#[cfg(feature = "std")]
+use fuel_types::Word;
+
+#[cfg(feature = "std")]
+use std::io;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum InputRepr {
+    Coin = 0x00,
+    Contract = 0x01,
+    Message = 0x02,
+}
+
+impl InputRepr {
+    pub const fn utxo_id_offset(&self) -> Option<usize> {
+        match self {
+            Self::Coin | Self::Contract => Some(INPUT_UTXO_ID_OFFSET),
+            Self::Message => None,
+        }
+    }
+
+    pub const fn owner_offset(&self) -> Option<usize> {
+        match self {
+            Self::Coin => Some(INPUT_COIN_OWNER_OFFSET),
+            Self::Message => Some(INPUT_MESSAGE_OWNER_OFFSET),
+            Self::Contract => None,
+        }
+    }
+
+    pub const fn asset_id_offset(&self) -> Option<usize> {
+        match self {
+            Self::Coin => Some(INPUT_COIN_ASSET_ID_OFFSET),
+            Self::Message | Self::Contract => None,
+        }
+    }
+
+    pub const fn data_offset(&self) -> Option<usize> {
+        match self {
+            Self::Message => Some(INPUT_MESSAGE_FIXED_SIZE),
+            Self::Coin | Self::Contract => None,
+        }
+    }
+
+    pub const fn coin_predicate_offset(&self) -> Option<usize> {
+        match self {
+            Self::Coin => Some(INPUT_COIN_FIXED_SIZE),
+            Self::Message | Self::Contract => None,
+        }
+    }
+
+    pub const fn contract_balance_root_offset(&self) -> Option<usize> {
+        match self {
+            Self::Contract => Some(INPUT_CONTRACT_BALANCE_ROOT_OFFSET),
+            Self::Message | Self::Coin => None,
+        }
+    }
+
+    pub const fn contract_state_root_offset(&self) -> Option<usize> {
+        match self {
+            Self::Contract => Some(INPUT_CONTRACT_STATE_ROOT_OFFSET),
+            Self::Message | Self::Coin => None,
+        }
+    }
+
+    pub const fn contract_id_offset(&self) -> Option<usize> {
+        match self {
+            Self::Contract => Some(INPUT_CONTRACT_ID_OFFSET),
+            Self::Message | Self::Coin => None,
+        }
+    }
+
+    pub const fn message_id_offset(&self) -> Option<usize> {
+        match self {
+            Self::Message => Some(INPUT_MESSAGE_ID_OFFSET),
+            Self::Contract | Self::Coin => None,
+        }
+    }
+
+    pub const fn message_sender_offset(&self) -> Option<usize> {
+        match self {
+            Self::Message => Some(INPUT_MESSAGE_SENDER_OFFSET),
+            Self::Contract | Self::Coin => None,
+        }
+    }
+
+    pub const fn message_recipient_offset(&self) -> Option<usize> {
+        match self {
+            Self::Message => Some(INPUT_MESSAGE_RECIPIENT_OFFSET),
+            Self::Contract | Self::Coin => None,
+        }
+    }
+
+    pub const fn from_input(input: &Input) -> Self {
+        match input {
+            Input::CoinSigned { .. } | Input::CoinPredicate { .. } => InputRepr::Coin,
+            Input::Contract { .. } => InputRepr::Contract,
+            Input::MessageSigned { .. } | Input::MessagePredicate { .. } => InputRepr::Message,
+        }
+    }
+}
+
+impl From<&Input> for InputRepr {
+    fn from(input: &Input) -> Self {
+        Self::from_input(input)
+    }
+}
+
+#[cfg(feature = "std")]
+impl TryFrom<Word> for InputRepr {
+    type Error = io::Error;
+
+    fn try_from(b: Word) -> Result<Self, Self::Error> {
+        match b {
+            0x00 => Ok(Self::Coin),
+            0x01 => Ok(Self::Contract),
+            0x02 => Ok(Self::Message),
+            id => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("The provided input identifier ({}) is invalid!", id),
+            )),
+        }
+    }
+}

--- a/src/transaction/types/output/consts.rs
+++ b/src/transaction/types/output/consts.rs
@@ -1,0 +1,25 @@
+use fuel_types::bytes::WORD_SIZE;
+use fuel_types::{Address, AssetId, Bytes32, ContractId};
+
+pub(super) const OUTPUT_CCV_TO_OFFSET: usize = WORD_SIZE; // Identifier
+pub(super) const OUTPUT_CCV_ASSET_ID_OFFSET: usize = OUTPUT_CCV_TO_OFFSET
+    + Address::LEN // To
+    + WORD_SIZE; // Amount
+pub(super) const OUTPUT_CCV_SIZE: usize = OUTPUT_CCV_ASSET_ID_OFFSET + AssetId::LEN; // AssetId
+
+pub(super) const OUTPUT_MESSAGE_RECIPIENT_OFFSET: usize = WORD_SIZE; // Identifier
+pub(super) const OUTPUT_MESSAGE_SIZE: usize = OUTPUT_MESSAGE_RECIPIENT_OFFSET
+    + Address::LEN // Recipient
+    + WORD_SIZE; // Amount
+
+pub(super) const OUTPUT_CONTRACT_BALANCE_ROOT_OFFSET: usize = WORD_SIZE // Identifier
+    + WORD_SIZE; // Input index
+pub(super) const OUTPUT_CONTRACT_STATE_ROOT_OFFSET: usize =
+    OUTPUT_CONTRACT_BALANCE_ROOT_OFFSET + Bytes32::LEN; // Balance root
+pub(super) const OUTPUT_CONTRACT_SIZE: usize = OUTPUT_CONTRACT_STATE_ROOT_OFFSET + Bytes32::LEN; // State root
+
+pub(super) const OUTPUT_CONTRACT_CREATED_ID_OFFSET: usize = WORD_SIZE; // Identifier
+pub(super) const OUTPUT_CONTRACT_CREATED_STATE_ROOT_OFFSET: usize =
+    OUTPUT_CONTRACT_CREATED_ID_OFFSET + ContractId::LEN; // Contract Id
+pub(super) const OUTPUT_CONTRACT_CREATED_SIZE: usize =
+    OUTPUT_CONTRACT_CREATED_STATE_ROOT_OFFSET + Bytes32::LEN; // State Root

--- a/src/transaction/types/output/repr.rs
+++ b/src/transaction/types/output/repr.rs
@@ -1,0 +1,116 @@
+use super::consts::*;
+use super::Output;
+
+#[cfg(feature = "std")]
+use fuel_types::Word;
+
+#[cfg(feature = "std")]
+use std::io;
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum OutputRepr {
+    Coin = 0x00,
+    Contract = 0x01,
+    Message = 0x02,
+    Change = 0x03,
+    Variable = 0x04,
+    ContractCreated = 0x05,
+}
+
+impl OutputRepr {
+    pub const fn to_offset(&self) -> Option<usize> {
+        match self {
+            OutputRepr::Coin | OutputRepr::Change | OutputRepr::Variable => {
+                Some(OUTPUT_CCV_TO_OFFSET)
+            }
+            _ => None,
+        }
+    }
+
+    pub const fn asset_id_offset(&self) -> Option<usize> {
+        match self {
+            OutputRepr::Coin | OutputRepr::Change | OutputRepr::Variable => {
+                Some(OUTPUT_CCV_ASSET_ID_OFFSET)
+            }
+            _ => None,
+        }
+    }
+
+    pub const fn contract_balance_root_offset(&self) -> Option<usize> {
+        match self {
+            Self::Contract => Some(OUTPUT_CONTRACT_BALANCE_ROOT_OFFSET),
+            _ => None,
+        }
+    }
+
+    pub const fn contract_state_root_offset(&self) -> Option<usize> {
+        match self {
+            Self::Contract => Some(OUTPUT_CONTRACT_STATE_ROOT_OFFSET),
+            _ => None,
+        }
+    }
+
+    pub const fn contract_created_state_root_offset(&self) -> Option<usize> {
+        match self {
+            Self::ContractCreated => Some(OUTPUT_CONTRACT_CREATED_STATE_ROOT_OFFSET),
+            _ => None,
+        }
+    }
+
+    pub const fn contract_id_offset(&self) -> Option<usize> {
+        match self {
+            Self::ContractCreated => Some(OUTPUT_CONTRACT_CREATED_ID_OFFSET),
+            _ => None,
+        }
+    }
+
+    pub const fn recipient_offset(&self) -> Option<usize> {
+        match self {
+            Self::Message => Some(OUTPUT_MESSAGE_RECIPIENT_OFFSET),
+            _ => None,
+        }
+    }
+
+    pub const fn from_output(output: &Output) -> Self {
+        match output {
+            Output::Coin { .. } => Self::Coin,
+            Output::Contract { .. } => Self::Contract,
+            Output::Message { .. } => Self::Message,
+            Output::Change { .. } => Self::Change,
+            Output::Variable { .. } => Self::Variable,
+            Output::ContractCreated { .. } => Self::ContractCreated,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl TryFrom<Word> for OutputRepr {
+    type Error = io::Error;
+
+    fn try_from(b: Word) -> Result<Self, Self::Error> {
+        match b {
+            0x00 => Ok(Self::Coin),
+            0x01 => Ok(Self::Contract),
+            0x02 => Ok(Self::Message),
+            0x03 => Ok(Self::Change),
+            0x04 => Ok(Self::Variable),
+            0x05 => Ok(Self::ContractCreated),
+            i => Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!("The provided output identifier ({}) is invalid!", i),
+            )),
+        }
+    }
+}
+
+impl From<&Output> for OutputRepr {
+    fn from(o: &Output) -> Self {
+        Self::from_output(o)
+    }
+}
+
+impl From<&mut Output> for OutputRepr {
+    fn from(o: &mut Output) -> Self {
+        Self::from_output(o)
+    }
+}

--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -1,7 +1,388 @@
 use fuel_tx::*;
 use fuel_tx_test_helpers::TransactionFactory;
 use fuel_types::bytes::{Deserializable, SerializableVec};
-use rand::{rngs::StdRng, Rng, SeedableRng};
+use rand::rngs::StdRng;
+use rand::{Rng, SeedableRng};
+
+#[test]
+fn tx_offset() {
+    // Assert everything is tested. If some of these bools fails, just increase the number of
+    // cases
+    let mut tested_salt = false;
+    let mut tested_slots = false;
+    let mut tested_utxo_id = false;
+    let mut tested_owner = false;
+    let mut tested_asset_id = false;
+    let mut tested_predicate_coin = false;
+    let mut tested_predicate_message = false;
+    let mut tested_predicate_data_coin = false;
+    let mut tested_predicate_data_message = false;
+    let mut tested_contract_balance_root = false;
+    let mut tested_contract_state_root = false;
+    let mut tested_contract_id = false;
+    let mut tested_message_id = false;
+    let mut tested_sender = false;
+    let mut tested_recipient = false;
+    let mut tested_message_owner = false;
+    let mut tested_message_data = false;
+    let mut tested_message_predicate = false;
+    let mut tested_message_predicate_data = false;
+    let mut tested_output_to = false;
+    let mut tested_output_asset_id = false;
+    let mut tested_output_balance_root = false;
+    let mut tested_output_contract_state_root = false;
+    let mut tested_output_contract_created_state_root = false;
+    let mut tested_output_contract_created_id = false;
+    let mut tested_output_recipient = false;
+
+    let cases = 3;
+
+    TransactionFactory::from_seed(1296)
+        .take(cases)
+        .for_each(|(mut tx, _)| {
+            let bytes = tx.to_bytes();
+
+            if let Some(salt) = tx.salt() {
+                tested_salt = true;
+
+                let ofs = tx.salt_offset().expect("tx with salt is create");
+                let salt_p = unsafe { Salt::as_ref_unchecked(&bytes[ofs..ofs + Salt::LEN]) };
+
+                assert_eq!(salt, salt_p);
+            }
+
+            if let Some(slots) = tx.storage_slots() {
+                slots.iter().enumerate().for_each(|(idx, slot)| {
+                    tested_slots = true;
+
+                    let ofs = tx
+                        .storage_slot_offset(idx)
+                        .expect("tx with slots contains offsets");
+
+                    let bytes =
+                        unsafe { Bytes64::as_ref_unchecked(&bytes[ofs..ofs + Bytes64::LEN]) };
+
+                    let slot_p = StorageSlot::from(bytes);
+
+                    assert_eq!(slot, &slot_p);
+                })
+            }
+
+            tx.inputs().iter().enumerate().for_each(|(idx, i)| {
+                let input_ofs = tx.input_offset(idx).expect("failed to fetch input offset");
+                let i_p =
+                    Input::from_bytes(&bytes[input_ofs..]).expect("failed to deserialize input");
+
+                assert_eq!(i, &i_p);
+
+                if let Some(utxo_id) = i.utxo_id() {
+                    tested_utxo_id = true;
+
+                    let ofs = input_ofs + i.repr().utxo_id_offset().expect("input have utxo_id");
+                    let utxo_id_p =
+                        UtxoId::from_bytes(&bytes[ofs..]).expect("failed to deserialize utxo id");
+
+                    assert_eq!(utxo_id, &utxo_id_p);
+                }
+
+                if let Some(owner) = i.input_owner() {
+                    tested_owner = true;
+
+                    let ofs = input_ofs + i.repr().owner_offset().expect("input contains owner");
+                    let owner_p =
+                        unsafe { Address::as_ref_unchecked(&bytes[ofs..ofs + Address::LEN]) };
+
+                    assert_eq!(owner, owner_p);
+                }
+
+                if let Some(asset_id) = i.asset_id() {
+                    tested_asset_id = true;
+
+                    let ofs =
+                        input_ofs + i.repr().asset_id_offset().expect("input contains asset id");
+                    let asset_id_p =
+                        unsafe { AssetId::as_ref_unchecked(&bytes[ofs..ofs + AssetId::LEN]) };
+
+                    assert_eq!(asset_id, asset_id_p);
+                }
+
+                if let Some(predicate) = i.input_predicate() {
+                    tested_predicate_coin =
+                        tested_predicate_coin || i.is_coin() && !predicate.is_empty();
+                    tested_predicate_message =
+                        tested_predicate_message || i.is_message() && !predicate.is_empty();
+
+                    let ofs = input_ofs + i.predicate_offset().expect("input contains predicate");
+                    let predicate_p = &bytes[ofs..ofs + predicate.len()];
+
+                    assert_eq!(predicate, predicate_p);
+                }
+
+                if let Some(predicate_data) = i.input_predicate_data() {
+                    tested_predicate_data_coin =
+                        tested_predicate_data_coin || i.is_coin() && !predicate_data.is_empty();
+                    tested_predicate_data_message = tested_predicate_data_message
+                        || i.is_message() && !predicate_data.is_empty();
+
+                    let ofs = input_ofs
+                        + i.predicate_data_offset()
+                            .expect("input contains predicate data");
+                    let predicate_data_p = &bytes[ofs..ofs + predicate_data.len()];
+
+                    assert_eq!(predicate_data, predicate_data_p);
+                }
+
+                if let Some(balance_root) = i.balance_root() {
+                    tested_contract_balance_root = true;
+
+                    let ofs = input_ofs
+                        + i.repr()
+                            .contract_balance_root_offset()
+                            .expect("input contains balance root");
+
+                    let balance_root_p =
+                        unsafe { Bytes32::as_ref_unchecked(&bytes[ofs..ofs + Bytes32::LEN]) };
+
+                    assert_eq!(balance_root, balance_root_p);
+                }
+
+                if let Some(state_root) = i.state_root() {
+                    tested_contract_state_root = true;
+
+                    let ofs = input_ofs
+                        + i.repr()
+                            .contract_state_root_offset()
+                            .expect("input contains state root");
+
+                    let state_root_p =
+                        unsafe { Bytes32::as_ref_unchecked(&bytes[ofs..ofs + Bytes32::LEN]) };
+
+                    assert_eq!(state_root, state_root_p);
+                }
+
+                if let Some(contract_id) = i.contract_id() {
+                    tested_contract_id = true;
+
+                    let ofs = input_ofs
+                        + i.repr()
+                            .contract_id_offset()
+                            .expect("input contains contract id");
+
+                    let contract_id_p =
+                        unsafe { ContractId::as_ref_unchecked(&bytes[ofs..ofs + ContractId::LEN]) };
+
+                    assert_eq!(contract_id, contract_id_p);
+                }
+
+                if let Some(message_id) = i.message_id() {
+                    tested_message_id = true;
+
+                    let ofs = input_ofs
+                        + i.repr()
+                            .message_id_offset()
+                            .expect("input contains message id");
+
+                    let message_id_p =
+                        unsafe { MessageId::as_ref_unchecked(&bytes[ofs..ofs + MessageId::LEN]) };
+
+                    assert_eq!(message_id, message_id_p);
+                }
+
+                if let Some(sender) = i.sender() {
+                    tested_sender = true;
+
+                    let ofs = input_ofs
+                        + i.repr()
+                            .message_sender_offset()
+                            .expect("input contains sender");
+
+                    let sender_p =
+                        unsafe { Address::as_ref_unchecked(&bytes[ofs..ofs + Address::LEN]) };
+
+                    assert_eq!(sender, sender_p);
+                }
+
+                if let Some(recipient) = i.recipient() {
+                    tested_recipient = true;
+
+                    let ofs = input_ofs
+                        + i.repr()
+                            .message_recipient_offset()
+                            .expect("input contains recipient");
+
+                    let recipient_p =
+                        unsafe { Address::as_ref_unchecked(&bytes[ofs..ofs + Address::LEN]) };
+
+                    assert_eq!(recipient, recipient_p);
+                }
+
+                if i.is_message() {
+                    if let Some(owner) = i.input_owner() {
+                        tested_message_owner = true;
+
+                        let ofs =
+                            input_ofs + i.repr().owner_offset().expect("input contains owner");
+
+                        let owner_p =
+                            unsafe { Address::as_ref_unchecked(&bytes[ofs..ofs + Address::LEN]) };
+
+                        assert_eq!(owner, owner_p);
+                    }
+                }
+
+                if let Some(data) = i.input_data() {
+                    tested_message_data = tested_message_data || !data.is_empty();
+
+                    let ofs = input_ofs + i.repr().data_offset().expect("input contains data");
+                    let data_p = &bytes[ofs..ofs + data.len()];
+
+                    assert_eq!(data, data_p);
+                }
+
+                if i.is_message() {
+                    if let Some(predicate) = i.input_predicate() {
+                        tested_message_predicate =
+                            tested_message_predicate || !predicate.is_empty();
+
+                        let ofs =
+                            input_ofs + i.predicate_offset().expect("input contains predicate");
+                        let predicate_p = &bytes[ofs..ofs + predicate.len()];
+
+                        assert_eq!(predicate, predicate_p);
+                    }
+                }
+
+                if i.is_message() {
+                    if let Some(predicate_data) = i.input_predicate_data() {
+                        tested_message_predicate_data =
+                            tested_message_predicate_data || !predicate_data.is_empty();
+
+                        let ofs = input_ofs
+                            + i.predicate_data_offset()
+                                .expect("input contains predicate data");
+                        let predicate_data_p = &bytes[ofs..ofs + predicate_data.len()];
+
+                        assert_eq!(predicate_data, predicate_data_p);
+                    }
+                }
+            });
+
+            tx.outputs().iter().enumerate().for_each(|(idx, o)| {
+                let output_ofs = tx
+                    .output_offset(idx)
+                    .expect("failed to fetch output offset");
+                let o_p =
+                    Output::from_bytes(&bytes[output_ofs..]).expect("failed to deserialize output");
+
+                assert_eq!(o, &o_p);
+
+                if let Some(to) = o.to() {
+                    tested_output_to = true;
+
+                    let ofs = output_ofs + o.repr().to_offset().expect("output have to");
+                    let to_p =
+                        unsafe { Address::as_ref_unchecked(&bytes[ofs..ofs + Address::LEN]) };
+
+                    assert_eq!(to, to_p);
+                }
+
+                if let Some(asset_id) = o.asset_id() {
+                    tested_output_asset_id = true;
+
+                    let ofs =
+                        output_ofs + o.repr().asset_id_offset().expect("output have asset id");
+                    let asset_id_p =
+                        unsafe { AssetId::as_ref_unchecked(&bytes[ofs..ofs + Address::LEN]) };
+
+                    assert_eq!(asset_id, asset_id_p);
+                }
+
+                if let Some(balance_root) = o.balance_root() {
+                    tested_output_balance_root = true;
+
+                    let ofs = output_ofs
+                        + o.repr()
+                            .contract_balance_root_offset()
+                            .expect("output have balance root");
+                    let balance_root_p =
+                        unsafe { Bytes32::as_ref_unchecked(&bytes[ofs..ofs + Bytes32::LEN]) };
+
+                    assert_eq!(balance_root, balance_root_p);
+                }
+
+                if let Some(state_root) = o.state_root() {
+                    let ofs = if o.is_contract() {
+                        tested_output_contract_state_root = true;
+                        o.repr()
+                            .contract_state_root_offset()
+                            .expect("output have state root")
+                    } else {
+                        tested_output_contract_created_state_root = true;
+                        o.repr()
+                            .contract_created_state_root_offset()
+                            .expect("output have state root")
+                    };
+
+                    let ofs = output_ofs + ofs;
+                    let state_root_p =
+                        unsafe { Bytes32::as_ref_unchecked(&bytes[ofs..ofs + Bytes32::LEN]) };
+
+                    assert_eq!(state_root, state_root_p);
+                }
+
+                if let Some(contract_id) = o.contract_id() {
+                    tested_output_contract_created_id = true;
+
+                    let ofs = output_ofs
+                        + o.repr()
+                            .contract_id_offset()
+                            .expect("output have contract id");
+                    let contract_id_p =
+                        unsafe { ContractId::as_ref_unchecked(&bytes[ofs..ofs + ContractId::LEN]) };
+
+                    assert_eq!(contract_id, contract_id_p);
+                }
+
+                if let Some(recipient) = o.recipient() {
+                    tested_output_recipient = true;
+
+                    let ofs =
+                        output_ofs + o.repr().recipient_offset().expect("output have recipient");
+                    let recipient_p =
+                        unsafe { Address::as_ref_unchecked(&bytes[ofs..ofs + Address::LEN]) };
+
+                    assert_eq!(recipient, recipient_p);
+                }
+            });
+        });
+
+    assert!(tested_salt);
+    assert!(tested_slots);
+    assert!(tested_utxo_id);
+    assert!(tested_owner);
+    assert!(tested_asset_id);
+    assert!(tested_predicate_coin);
+    assert!(tested_predicate_message);
+    assert!(tested_predicate_data_coin);
+    assert!(tested_predicate_data_message);
+    assert!(tested_contract_balance_root);
+    assert!(tested_contract_state_root);
+    assert!(tested_contract_id);
+    assert!(tested_message_id);
+    assert!(tested_sender);
+    assert!(tested_recipient);
+    assert!(tested_message_owner);
+    assert!(tested_message_data);
+    assert!(tested_message_predicate);
+    assert!(tested_message_predicate_data);
+    assert!(tested_output_to);
+    assert!(tested_output_asset_id);
+    assert!(tested_output_balance_root);
+    assert!(tested_output_contract_state_root);
+    assert!(tested_output_contract_created_state_root);
+    assert!(tested_output_contract_created_id);
+    assert!(tested_output_recipient);
+}
 
 #[test]
 fn iow_offset() {


### PR DESCRIPTION
The newly introduced instruction `GTF` will set the internal registers
of the interpreter with metadata of the transaction structure.

In order to not leak implementation details of the transaction to the
VM, we need several new helper functions.