### PR TITLE
Fix issues with tx init procedures

### DIFF
--- a/src/checked_transaction.rs
+++ b/src/checked_transaction.rs
@@ -249,14 +249,9 @@ impl CheckedTransaction {
     }
 
     /// Prepare the transaction for VM initialization for script execution
-    ///
-    /// The callback argument is to expect a contract id and return its balance root and state root
     #[cfg(feature = "std")]
-    pub fn prepare_init_script<F>(&mut self, f: F) -> io::Result<&mut Self>
-    where
-        F: FnMut(&fuel_types::ContractId) -> io::Result<(Bytes32, Bytes32)>,
-    {
-        self.transaction.prepare_init_script(f)?;
+    pub fn prepare_init_script<F>(&mut self) -> io::Result<&mut Self> {
+        self.transaction.prepare_init_script()?;
         Ok(self)
     }
 

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -470,29 +470,15 @@ impl Transaction {
     }
 
     /// Prepare the transaction for VM initialization for script execution
-    ///
-    /// The callback argument is to expect a contract id and return its balance root and state root
     #[cfg(feature = "std")]
-    pub fn prepare_init_script<F>(&mut self, mut f: F) -> io::Result<&mut Self>
-    where
-        F: FnMut(&fuel_types::ContractId) -> io::Result<(Bytes32, Bytes32)>,
-    {
-        let id = self.id();
-
-        let (inputs, outputs) = match self {
-            Transaction::Script {
-                inputs, outputs, ..
-            }
-            | Transaction::Create {
-                inputs, outputs, ..
-            } => (inputs, outputs),
+    pub fn prepare_init_script(&mut self) -> io::Result<&mut Self> {
+        let outputs = match self {
+            Transaction::Script { outputs, .. } | Transaction::Create { outputs, .. } => outputs,
         };
-
-        inputs.iter_mut().for_each(|i| i.prepare_init_script(id));
 
         outputs
             .iter_mut()
-            .try_for_each(|o| o.prepare_init_script(inputs, &mut f))?;
+            .try_for_each(|o| o.prepare_init_script())?;
 
         Ok(self)
     }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -470,6 +470,9 @@ impl Transaction {
     }
 
     /// Prepare the transaction for VM initialization for script execution
+    ///
+    /// note: Fields dependent on storage/state such as balance and state roots, or tx pointers,
+    /// should already set by the client beforehand.
     #[cfg(feature = "std")]
     pub fn prepare_init_script(&mut self) -> io::Result<&mut Self> {
         let outputs = match self {

--- a/src/transaction/types/input.rs
+++ b/src/transaction/types/input.rs
@@ -1,4 +1,4 @@
-use crate::{TxId, TxPointer, UtxoId};
+use crate::{TxPointer, UtxoId};
 
 use fuel_crypto::{Hasher, PublicKey};
 use fuel_types::bytes;
@@ -540,31 +540,6 @@ impl Input {
         owner == &Self::predicate_owner(predicate)
     }
 
-    /// Prepare the output for VM initialization
-    pub fn prepare_init_script(&mut self, tx_id: Bytes32) {
-        match self {
-            Input::CoinSigned { tx_pointer, .. } | Input::CoinPredicate { tx_pointer, .. } => {
-                mem::take(tx_pointer);
-            }
-
-            Input::Contract {
-                utxo_id,
-                balance_root,
-                state_root,
-                tx_pointer,
-                ..
-            } => {
-                mem::take(tx_pointer);
-                utxo_id.replace_tx_id(tx_id);
-
-                *balance_root = (*tx_id).into();
-                *state_root = (*tx_id).into();
-            }
-
-            _ => (),
-        }
-    }
-
     /// Prepare the output for VM predicate execution
     pub fn prepare_init_predicate(&mut self) {
         match self {
@@ -582,7 +557,7 @@ impl Input {
                 mem::take(tx_pointer);
                 mem::take(balance_root);
                 mem::take(state_root);
-                utxo_id.replace_tx_id(TxId::zeroed());
+                mem::take(utxo_id);
             }
 
             _ => (),

--- a/src/transaction/types/output.rs
+++ b/src/transaction/types/output.rs
@@ -5,9 +5,6 @@ use fuel_types::{Address, AssetId, Bytes32, ContractId, MessageId, Word};
 use core::mem;
 
 #[cfg(feature = "std")]
-use crate::Input;
-
-#[cfg(feature = "std")]
 use fuel_types::bytes::{SizedBytes, WORD_SIZE};
 
 #[cfg(feature = "std")]
@@ -242,28 +239,8 @@ impl Output {
 
     /// Prepare the output for VM initialization for script execution
     #[cfg(feature = "std")]
-    pub fn prepare_init_script<F>(&mut self, inputs: &[Input], f: F) -> io::Result<()>
-    where
-        F: FnMut(&fuel_types::ContractId) -> io::Result<(Bytes32, Bytes32)>,
-    {
-        use fuel_asm::PanicReason;
-
+    pub fn prepare_init_script(&mut self) -> io::Result<()> {
         match self {
-            Output::Contract {
-                balance_root,
-                state_root,
-                input_index,
-            } => {
-                let (initial_balance_root, initial_state_root) = inputs
-                    .get(*input_index as usize)
-                    .and_then(Input::contract_id)
-                    .ok_or_else(|| io::Error::new(io::ErrorKind::Other, PanicReason::InputNotFound))
-                    .and_then(f)?;
-
-                *balance_root = initial_balance_root;
-                *state_root = initial_state_root;
-            }
-
             Output::Message { recipient, amount } => {
                 mem::take(recipient);
                 mem::take(amount);


### PR DESCRIPTION
Remove faulty logic for script init, as the values like stateRoot and balanceRoot are derived from storage/state and not the tx format itself. Furthermore, the utxoid should be unique for each contract input, instead of being set to the currently executing tx.

Updated specs to try to clarify some of this: https://github.com/FuelLabs/fuel-specs/pull/394