### PR TITLE
In some function missed `MessageSigned` and `MessagePredicate` functionality

### DIFF
--- a/src/checked_transaction.rs
+++ b/src/checked_transaction.rs
@@ -17,7 +17,7 @@ use core::{borrow::Borrow, ops::Index};
 use core::mem;
 use std::io::{self, Read};
 
-const BASE_ASSET: AssetId = AssetId::zeroed();
+pub const BASE_ASSET: AssetId = AssetId::zeroed();
 
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 // Avoid serde serialization of this type. Since checked tx would need to be re-validated on

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,3 +1,4 @@
+use crate::checked_transaction::BASE_ASSET;
 use crate::consts::*;
 
 use fuel_asm::Opcode;
@@ -158,6 +159,7 @@ impl Transaction {
             Input::CoinPredicate { asset_id, .. } | Input::CoinSigned { asset_id, .. } => {
                 Some(asset_id)
             }
+            Input::MessagePredicate { .. } | Input::MessageSigned { .. } => Some(&BASE_ASSET),
             _ => None,
         })
     }
@@ -222,6 +224,11 @@ impl Transaction {
                 Input::CoinPredicate {
                     owner, predicate, ..
                 } => Some((owner, predicate)),
+                Input::MessagePredicate {
+                    recipient,
+                    predicate,
+                    ..
+                } => Some((recipient, predicate)),
                 _ => None,
             })
             .fold(true, |result, (owner, predicate)| {
@@ -231,11 +238,17 @@ impl Transaction {
 
     #[cfg(feature = "std")]
     pub fn check_predicate_owner(&self, idx: usize) -> bool {
-        matches!(self.inputs().get(idx),
-        Some(Input::CoinPredicate {
-                            owner, predicate, ..
-                        }) if Input::is_predicate_owner_valid(owner, predicate)
-                )
+        match self.inputs().get(idx) {
+            Some(Input::CoinPredicate {
+                owner, predicate, ..
+            }) => Input::is_predicate_owner_valid(owner, predicate),
+            Some(Input::MessagePredicate {
+                recipient,
+                predicate,
+                ..
+            }) => Input::is_predicate_owner_valid(recipient, predicate),
+            _ => false,
+        }
     }
 
     pub const fn gas_price(&self) -> Word {

--- a/src/transaction/types/input/repr.rs
+++ b/src/transaction/types/input/repr.rs
@@ -25,7 +25,7 @@ impl InputRepr {
     pub const fn owner_offset(&self) -> Option<usize> {
         match self {
             Self::Coin => Some(INPUT_COIN_OWNER_OFFSET),
-            Self::Message => None,
+            Self::Message => Some(INPUT_MESSAGE_RECIPIENT_OFFSET),
             Self::Contract => None,
         }
     }

--- a/tests/offset.rs
+++ b/tests/offset.rs
@@ -99,14 +99,16 @@ fn tx_offset() {
                 }
 
                 if let Some(asset_id) = i.asset_id() {
-                    tested_asset_id = true;
+                    // Messages don't store `AssetId` explicitly but work with base asset
+                    if let Some(offset) = i.repr().asset_id_offset() {
+                        tested_asset_id = true;
 
-                    let ofs =
-                        input_ofs + i.repr().asset_id_offset().expect("input contains asset id");
-                    let asset_id_p =
-                        unsafe { AssetId::as_ref_unchecked(&bytes[ofs..ofs + AssetId::LEN]) };
+                        let ofs = input_ofs + offset;
+                        let asset_id_p =
+                            unsafe { AssetId::as_ref_unchecked(&bytes[ofs..ofs + AssetId::LEN]) };
 
-                    assert_eq!(asset_id, asset_id_p);
+                        assert_eq!(asset_id, asset_id_p);
+                    }
                 }
 
                 if let Some(predicate) = i.input_predicate() {


### PR DESCRIPTION
In the tests for https://github.com/FuelLabs/fuel-core/pull/632, I found the handling of the `MessageSigned` and `MessagePredicate` inputs is missing in some methods. 