### PR TITLE
v0.21.0: contract id for panic receipt

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "fuel-tx"
-version = "0.20.2"
+version = "0.21.0"
 authors = ["Fuel Labs <contact@fuel.sh>"]
 categories = ["cryptography::cryptocurrencies", "data-structures"]
 edition = "2021"


### PR DESCRIPTION
breaking change since enum fields are public and exhaustive

cc @Salka1988 